### PR TITLE
Add Query builder and pipeline unit tests

### DIFF
--- a/tests/KsqlDslTests.csproj
+++ b/tests/KsqlDslTests.csproj
@@ -1,6 +1,7 @@
 ﻿
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <AssemblyName>KsqlDsl.Tests</AssemblyName>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Query/Builders/GroupByBuilderTests.cs
+++ b/tests/Query/Builders/GroupByBuilderTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class GroupByBuilderTests
+{
+    [Fact]
+    public void Build_GroupByMultipleKeys_ReturnsClause()
+    {
+        Expression<Func<TestEntity, object>> expr = e => new { e.Id, e.Type };
+        var builder = new GroupByBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("GROUP BY Id, Type", result);
+    }
+}

--- a/tests/Query/Builders/ProjectionBuilderTests.cs
+++ b/tests/Query/Builders/ProjectionBuilderTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class ProjectionBuilderTests
+{
+    [Fact]
+    public void Build_NewExpressionWithAlias_ReturnsSelectClause()
+    {
+        Expression<Func<TestEntity, object>> expr = e => new { e.Id, Renamed = e.Name };
+        var builder = new ProjectionBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("SELECT Id, Name AS Renamed", result);
+    }
+
+    [Fact]
+    public void Build_ParameterExpression_ReturnsSelectAll()
+    {
+        Expression<Func<TestEntity, TestEntity>> expr = e => e;
+        var builder = new ProjectionBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("SELECT *", result);
+    }
+}

--- a/tests/Query/Builders/SelectBuilderTests.cs
+++ b/tests/Query/Builders/SelectBuilderTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class SelectBuilderTests
+{
+    [Fact]
+    public void Build_SimpleEquality_ReturnsWhereClause()
+    {
+        Expression<Func<TestEntity, bool>> expr = e => e.Id == 1;
+        var builder = new SelectBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("WHERE (Id = 1)", result);
+    }
+
+    [Fact]
+    public void BuildCondition_BooleanNegation_IncludesParameterPrefix()
+    {
+        Expression<Func<TestEntity, bool>> expr = e => !e.IsActive;
+        var builder = new SelectBuilder();
+        var result = builder.BuildCondition(expr.Body);
+        Assert.Equal("(e.IsActive = false)", result);
+    }
+}

--- a/tests/Query/Builders/WindowBuilderTests.cs
+++ b/tests/Query/Builders/WindowBuilderTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class WindowBuilderTests
+{
+    [Fact]
+    public void Build_TumblingWindowWithFinal_ReturnsClause()
+    {
+        Expression<Func<WindowDef, WindowDef>> expr = w => w.TumblingWindow().Size(TimeSpan.FromMinutes(1)).EmitFinal();
+        var builder = new WindowBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("WINDOW TUMBLING (SIZE 1 MINUTES) EMIT FINAL", result);
+    }
+}

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Query.Pipeline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Pipeline;
+
+public class DDLQueryGeneratorTests
+{
+    private static EntityModel CreateEntityModel()
+    {
+        return new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! },
+            AllProperties = typeof(TestEntity).GetProperties()
+        };
+    }
+
+    [Fact]
+    public void GenerateCreateStream_CreatesExpectedStatement()
+    {
+        var model = CreateEntityModel();
+        var generator = new DDLQueryGenerator(new NullLoggerFactory());
+        var query = generator.GenerateCreateStream("s1", "topic", model);
+        Assert.Contains("CREATE STREAM s1", query);
+        Assert.Contains("KAFKA_TOPIC='topic'", query);
+    }
+
+    [Fact]
+    public void GenerateCreateTableAs_WithWhereAndGroupBy()
+    {
+        IQueryable<TestEntity> source = new List<TestEntity>().AsQueryable();
+        var expr = source.Where(e => e.IsActive)
+                         .GroupBy(e => e.Type)
+                         .Select(g => new { g.Key, Count = g.Count() });
+        var generator = new DDLQueryGenerator(new NullLoggerFactory());
+        var query = generator.GenerateCreateTableAs("t1", "Base", expr.Expression);
+        Assert.Contains("CREATE TABLE t1 AS SELECT", query);
+        Assert.Contains("FROM Base", query);
+        Assert.Contains("WHERE (IsActive = true)", query);
+        Assert.Contains("GROUP BY Type", query);
+    }
+}

--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Pipeline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Pipeline;
+
+public class DMLQueryGeneratorTests
+{
+    [Fact]
+    public void GenerateSelectAll_WithPushQuery_AppendsEmitChanges()
+    {
+        var generator = new DMLQueryGenerator(new NullLoggerFactory());
+        var query = generator.GenerateSelectAll("s1", isPullQuery: false);
+        Assert.Equal("SELECT * FROM s1 EMIT CHANGES", query);
+    }
+
+    [Fact]
+    public void GenerateSelectWithCondition_Basic()
+    {
+        Expression<Func<TestEntity, bool>> expr = e => e.Id == 1;
+        var generator = new DMLQueryGenerator(new NullLoggerFactory());
+        var query = generator.GenerateSelectWithCondition("s1", expr.Body, false);
+        Assert.Equal("SELECT * FROM s1 WHERE (Id = 1) EMIT CHANGES", query);
+    }
+}

--- a/tests/Query/Pipeline/QueryDiagnosticsTests.cs
+++ b/tests/Query/Pipeline/QueryDiagnosticsTests.cs
@@ -1,0 +1,21 @@
+using KsqlDsl.Query.Pipeline;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Pipeline;
+
+public class QueryDiagnosticsTests
+{
+    [Fact]
+    public void LogStep_And_Metadata_AppearInReport()
+    {
+        var diag = new QueryDiagnostics();
+        diag.LogStep("step1");
+        diag.SetMetadata("Key", "Value");
+        diag.MarkComplete();
+        var report = diag.GenerateReport();
+        Assert.Contains("step1", report);
+        Assert.Contains("Key: Value", report);
+        var summary = diag.GetSummary();
+        Assert.Contains("Query:", summary);
+    }
+}

--- a/tests/Query/Pipeline/StreamTableAnalyzerTests.cs
+++ b/tests/Query/Pipeline/StreamTableAnalyzerTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using KsqlDsl.Query.Pipeline;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Pipeline;
+
+public class StreamTableAnalyzerTests
+{
+    [Fact]
+    public void Analyze_SimpleWhereSelect_ReturnsStreamOutput()
+    {
+        IQueryable<TestEntity> source = new List<TestEntity>().AsQueryable();
+        var query = source.Where(e => e.IsActive).Select(e => new { e.Id });
+        var analyzer = new StreamTableAnalyzer(new NullLoggerFactory());
+
+        var result = analyzer.AnalyzeExpression(query.Expression);
+
+        Assert.False(result.HasGroupBy);
+        Assert.False(result.HasAggregation);
+        Assert.True(result.RequiresStreamOutput);
+        Assert.False(result.RequiresTableOutput);
+        Assert.Equal(new[] {"Where", "Select"}, result.OperationChain.Select(o => o.MethodName));
+    }
+
+    [Fact]
+    public void Analyze_GroupBySelect_ReturnsTableOutput()
+    {
+        IQueryable<TestEntity> source = new List<TestEntity>().AsQueryable();
+        var query = source.GroupBy(e => e.Type).Select(g => new { g.Key, Count = g.Count() });
+        var analyzer = new StreamTableAnalyzer(new NullLoggerFactory());
+
+        var result = analyzer.AnalyzeExpression(query.Expression);
+
+        Assert.True(result.HasGroupBy);
+        Assert.True(result.HasAggregation);
+        Assert.False(result.RequiresStreamOutput);
+        Assert.True(result.RequiresTableOutput);
+    }
+}

--- a/tests/Query/TestEntities.cs
+++ b/tests/Query/TestEntities.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace KsqlDsl.Tests;
+
+public class TestEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsActive { get; set; }
+    public bool? IsProcessed { get; set; }
+    public string Type { get; set; } = string.Empty;
+}
+
+public class ChildEntity
+{
+    public int Id { get; set; }
+    public int ParentId { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class WindowDef
+{
+    public WindowDef TumblingWindow() => this;
+    public WindowDef HoppingWindow() => this;
+    public WindowDef SessionWindow() => this;
+    public WindowDef Size(TimeSpan ts) => this;
+    public WindowDef AdvanceBy(TimeSpan ts) => this;
+    public WindowDef Gap(TimeSpan ts) => this;
+    public WindowDef Retention(TimeSpan ts) => this;
+    public WindowDef GracePeriod(TimeSpan ts) => this;
+    public WindowDef EmitFinal() => this;
+}


### PR DESCRIPTION
## Summary
- create helper test entities
- add unit tests for query builders
- cover StreamTableAnalyzer and query generators
- log step & metadata tests for QueryDiagnostics
- set test assembly name for `InternalsVisibleTo`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f1054ef483278abebd96c8da1e94