### PR TITLE
Add tests for Query components

### DIFF
--- a/tests/Query/Builders/BuilderUtilTests.cs
+++ b/tests/Query/Builders/BuilderUtilTests.cs
@@ -1,0 +1,18 @@
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders.Common;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class BuilderUtilTests
+{
+    [Fact]
+    public void ExtractMemberExpression_UnaryExpression_ReturnsMember()
+    {
+        Expression<Func<TestEntity, object>> expr = e => (object)e.Id;
+        var unary = (UnaryExpression)expr.Body;
+        var member = BuilderUtil.ExtractMemberExpression(unary);
+        Assert.NotNull(member);
+        Assert.Equal("Id", member!.Member.Name);
+    }
+}

--- a/tests/Query/Builders/HavingBuilderTests.cs
+++ b/tests/Query/Builders/HavingBuilderTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class HavingBuilderTests
+{
+    [Fact]
+    public void Build_CountWithoutSelector_ReturnsCountAll()
+    {
+        Expression<Func<IGrouping<int, TestEntity>, bool>> expr = g => g.Count() > 1;
+        var builder = new HavingBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("HAVING (COUNT(*) > 1)", result);
+    }
+
+    [Fact]
+    public void Build_SumWithLambda_ReturnsAggregateCondition()
+    {
+        Expression<Func<IGrouping<int, TestEntity>, bool>> expr = g => g.Sum(x => x.Id) > 5;
+        var builder = new HavingBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("HAVING (SUM(Id) > 5)", result);
+    }
+}

--- a/tests/Query/Builders/JoinBuilderTests.cs
+++ b/tests/Query/Builders/JoinBuilderTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using KsqlDsl.Query.Builders;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Builders;
+
+public class JoinBuilderTests
+{
+    [Fact]
+    public void Build_SimpleJoin_ReturnsJoinQuery()
+    {
+        IQueryable<TestEntity> outer = new List<TestEntity>().AsQueryable();
+        IQueryable<ChildEntity> inner = new List<ChildEntity>().AsQueryable();
+        var expr = outer.Join(inner, o => o.Id, c => c.ParentId, (o, c) => new { o.Id, c.Name }).Expression;
+        var builder = new JoinBuilder();
+        var result = builder.Build(expr);
+        Assert.StartsWith("SELECT o.Id, c.Name FROM TestEntity o JOIN ChildEntity c ON o.Id = c.ParentId", result);
+    }
+
+    [Fact]
+    public void Build_InvalidJoin_ReturnsErrorComment()
+    {
+        IQueryable<TestEntity> outer = new List<TestEntity>().AsQueryable();
+        IQueryable<ChildEntity> inner = new List<ChildEntity>().AsQueryable();
+        var expr = outer.Join(inner, o => new { o.Id }, c => new { c.ParentId, c.Id }, (o, c) => new { o.Id }).Expression;
+        var builder = new JoinBuilder();
+        var result = builder.Build(expr);
+        Assert.Contains("JOIN構築エラー", result);
+    }
+}

--- a/tests/Query/Ksql/KsqlDbRestApiClientTests.cs
+++ b/tests/Query/Ksql/KsqlDbRestApiClientTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using KsqlDsl.Query.Ksql;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Ksql;
+
+public class KsqlDbRestApiClientTests
+{
+    private class Handler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public Handler(HttpResponseMessage response) => _response = response;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => Task.FromResult(_response);
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_ParsesResponse()
+    {
+        var json = "{\"header\":{\"schema\":[{\"name\":\"ID\"}]}}\n{\"row\":{\"columns\":[1]}}";
+        var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+        var client = new KsqlDbRestApiClient("http://unit", new HttpClient(new Handler(message)));
+        var result = await client.ExecuteQueryAsync("select * from t");
+        Assert.Single(result.Header);
+        Assert.Single(result.Rows);
+        Assert.Equal(1, result.Rows[0]["ID"]);
+    }
+
+    [Fact]
+    public async Task ExecuteStatementAsync_ParsesResponse()
+    {
+        var json = "{\"statementText\":\"CREATE STREAM\",\"commandId\":\"1\"}";
+        var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(json) };
+        var client = new KsqlDbRestApiClient("http://unit", new HttpClient(new Handler(message)));
+        var result = await client.ExecuteStatementAsync("create stream");
+        Assert.Equal("CREATE STREAM", result.StatementText);
+        Assert.Equal("1", result.CommandId);
+    }
+}

--- a/tests/Query/Pipeline/DerivedObjectManagerTests.cs
+++ b/tests/Query/Pipeline/DerivedObjectManagerTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Query.Pipeline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Pipeline;
+
+public class DerivedObjectManagerTests
+{
+    private class FakeExecutor : KsqlDbExecutor
+    {
+        public List<string> ExecutedQueries { get; } = new();
+        public FakeExecutor() : base(new NullLoggerFactory()) { }
+        public override void ExecuteDDL(string ddlQuery) => ExecutedQueries.Add(ddlQuery);
+        public override Task ExecuteDDLAsync(string ddlQuery) { ExecutedQueries.Add(ddlQuery); return Task.CompletedTask; }
+        public override Task<List<T>> ExecutePullQueryAsync<T>(string query) => Task.FromResult(new List<T>());
+        public override Task<List<T>> ExecutePushQueryAsync<T>(string query) => Task.FromResult(new List<T>());
+        public override Task StopAllQueriesAsync() => Task.CompletedTask;
+        public override void Dispose() { }
+    }
+
+    [Fact]
+    public void CreateDerivedStream_AddsObjectAndExecutesDDL()
+    {
+        var executor = new FakeExecutor();
+        var ddl = new DDLQueryGenerator(new NullLoggerFactory());
+        var analyzer = new StreamTableAnalyzer(new NullLoggerFactory());
+        var manager = new DerivedObjectManager(executor, ddl, analyzer, new NullLoggerFactory());
+        IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();
+        var name = manager.CreateDerivedStream("Base", src.Expression);
+        Assert.Single(executor.ExecutedQueries);
+        Assert.Contains("CREATE STREAM", executor.ExecutedQueries[0]);
+        Assert.False(string.IsNullOrEmpty(name));
+    }
+
+    [Fact]
+    public async Task CleanupDerivedObjects_RemovesAll()
+    {
+        var executor = new FakeExecutor();
+        var ddl = new DDLQueryGenerator(new NullLoggerFactory());
+        var analyzer = new StreamTableAnalyzer(new NullLoggerFactory());
+        var manager = new DerivedObjectManager(executor, ddl, analyzer, new NullLoggerFactory());
+        IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();
+        manager.CreateDerivedStream("Base", src.Expression);
+        manager.CreateDerivedTable("Base", src.Expression);
+        await manager.CleanupDerivedObjectsAsync();
+        Assert.Empty(manager.GetType().GetField("_derivedObjects", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!.GetValue(manager) as System.Collections.IDictionary);
+    }
+}

--- a/tests/Query/Schema/SchemaRegistryTests.cs
+++ b/tests/Query/Schema/SchemaRegistryTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Query.Pipeline;
+using KsqlDsl.Query.Schema;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query.Schema;
+
+public class SchemaRegistryTests
+{
+    private class FakeExecutor : KsqlDbExecutor
+    {
+        public List<string> DdlQueries { get; } = new();
+        public FakeExecutor() : base(new NullLoggerFactory()) { }
+        public override void ExecuteDDL(string ddlQuery) => DdlQueries.Add(ddlQuery);
+        public override Task ExecuteDDLAsync(string ddlQuery) { DdlQueries.Add(ddlQuery); return Task.CompletedTask; }
+        public override Task<List<T>> ExecutePullQueryAsync<T>(string query) => Task.FromResult(new List<T>());
+        public override Task<List<T>> ExecutePushQueryAsync<T>(string query) => Task.FromResult(new List<T>());
+        public override Task StopAllQueriesAsync() => Task.CompletedTask;
+        public override void Dispose() { }
+    }
+
+    [KsqlStream]
+    private class StreamEntity
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public async Task RegisterSchemaAsync_UsesCreateTableWhenKeysPresent()
+    {
+        var executor = new FakeExecutor();
+        var ddl = new DDLQueryGenerator(new NullLoggerFactory());
+        var registry = new SchemaRegistry(executor, ddl, new NullLoggerFactory());
+        var model = new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! },
+            AllProperties = typeof(TestEntity).GetProperties()
+        };
+        await registry.RegisterSchemaAsync<TestEntity>(model);
+        Assert.Contains("CREATE TABLE", executor.DdlQueries.First());
+        Assert.True(registry.IsRegistered(typeof(TestEntity)));
+    }
+
+    [Fact]
+    public async Task RegisterSchemaAsync_StreamAttribute_UsesCreateStream()
+    {
+        var executor = new FakeExecutor();
+        var ddl = new DDLQueryGenerator(new NullLoggerFactory());
+        var registry = new SchemaRegistry(executor, ddl, new NullLoggerFactory());
+        var model = new EntityModel
+        {
+            EntityType = typeof(StreamEntity),
+            AllProperties = typeof(StreamEntity).GetProperties()
+        };
+        await registry.RegisterSchemaAsync<StreamEntity>(model);
+        Assert.Contains("CREATE STREAM", executor.DdlQueries.First());
+        Assert.True(registry.IsRegistered(typeof(StreamEntity)));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for HavingBuilder, JoinBuilder, and BuilderUtil
- add tests for DerivedObjectManager
- add tests for SchemaRegistry behavior
- add tests for KsqlDbRestApiClient parsing

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f86b04008327ba1033e79a69e38c