### PR TITLE
Add boundary tests for query builders

### DIFF
--- a/tests/Query/Builders/GroupByBuilderTests.cs
+++ b/tests/Query/Builders/GroupByBuilderTests.cs
@@ -15,4 +15,12 @@ public class GroupByBuilderTests
         var result = builder.Build(expr.Body);
         Assert.Equal("GROUP BY Id, Type", result);
     }
+
+    [Fact]
+    public void Build_NoKeys_ThrowsInvalidOperationException()
+    {
+        Expression<Func<TestEntity, TestEntity>> expr = e => e;
+        var builder = new GroupByBuilder();
+        Assert.Throws<InvalidOperationException>(() => builder.Build(expr.Body));
+    }
 }

--- a/tests/Query/Builders/HavingBuilderTests.cs
+++ b/tests/Query/Builders/HavingBuilderTests.cs
@@ -25,4 +25,11 @@ public class HavingBuilderTests
         var result = builder.Build(expr.Body);
         Assert.Equal("HAVING (SUM(Id) > 5)", result);
     }
+
+    [Fact]
+    public void Build_NullExpression_ThrowsArgumentNullException()
+    {
+        var builder = new HavingBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Build(null!));
+    }
 }

--- a/tests/Query/Builders/JoinBuilderTests.cs
+++ b/tests/Query/Builders/JoinBuilderTests.cs
@@ -38,4 +38,11 @@ public class JoinBuilderTests
         var result = builder.Build(expr);
         Assert.Contains("JOIN構築エラー", result);
     }
+
+    [Fact]
+    public void Build_NullExpression_ThrowsArgumentNullException()
+    {
+        var builder = new JoinBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Build(null!));
+    }
 }

--- a/tests/Query/Builders/ProjectionBuilderTests.cs
+++ b/tests/Query/Builders/ProjectionBuilderTests.cs
@@ -24,4 +24,12 @@ public class ProjectionBuilderTests
         var result = builder.Build(expr.Body);
         Assert.Equal("SELECT *", result);
     }
+
+    [Fact]
+    public void Build_UnsupportedOperator_ThrowsNotSupportedException()
+    {
+        Expression<Func<TestEntity, object>> expr = e => e.Name ?? "unknown";
+        var builder = new ProjectionBuilder();
+        Assert.Throws<NotSupportedException>(() => builder.Build(expr.Body));
+    }
 }

--- a/tests/Query/Builders/SelectBuilderTests.cs
+++ b/tests/Query/Builders/SelectBuilderTests.cs
@@ -24,4 +24,11 @@ public class SelectBuilderTests
         var result = builder.BuildCondition(expr.Body);
         Assert.Equal("(e.IsActive = false)", result);
     }
+
+    [Fact]
+    public void Build_NullExpression_ThrowsArgumentNullException()
+    {
+        var builder = new SelectBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Build(null!));
+    }
 }

--- a/tests/Query/Builders/WindowBuilderTests.cs
+++ b/tests/Query/Builders/WindowBuilderTests.cs
@@ -15,4 +15,11 @@ public class WindowBuilderTests
         var result = builder.Build(expr.Body);
         Assert.Equal("WINDOW TUMBLING (SIZE 1 MINUTES) EMIT FINAL", result);
     }
+
+    [Fact]
+    public void Build_NullExpression_ThrowsArgumentNullException()
+    {
+        var builder = new WindowBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Build(null!));
+    }
 }


### PR DESCRIPTION
## Summary
- extend builder test coverage with null and error scenarios

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857492366588327b0cc7963cf6f3718