### PR TITLE
Add unit tests for multiple namespaces

### DIFF
--- a/tests/Application/AvroSchemaInfoExtensionsTests.cs
+++ b/tests/Application/AvroSchemaInfoExtensionsTests.cs
@@ -1,0 +1,36 @@
+using KsqlDsl.Application;
+using KsqlDsl.Serialization.Avro.Core;
+using Xunit;
+using KsqlDsl.Tests;
+
+namespace KsqlDsl.Tests.Application;
+
+public class AvroSchemaInfoExtensionsTests
+{
+    [Fact]
+    public void Subjects_ReturnExpectedStrings()
+    {
+        var info = new AvroSchemaInfo { TopicName = "test" };
+        Assert.Equal("test-key", info.GetKeySubject());
+        Assert.Equal("test-value", info.GetValueSubject());
+    }
+
+    [Fact]
+    public void GetStreamTableType_UsesHasCustomKey()
+    {
+        var info = new AvroSchemaInfo { TopicName = "t", HasCustomKey = true };
+        Assert.Equal("Table", info.GetStreamTableType());
+    }
+
+    [Fact]
+    public void GetKeyTypeName_ReturnsComposite_WhenMultipleKeyProps()
+    {
+        var info = new AvroSchemaInfo
+        {
+            TopicName = "t",
+            HasCustomKey = true,
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))!, typeof(TestEntity).GetProperty(nameof(TestEntity.Name))! }
+        };
+        Assert.Equal("CompositeKey", info.GetKeyTypeName());
+    }
+}

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -1,0 +1,27 @@
+using KsqlDsl.Application;
+using Xunit;
+
+namespace KsqlDsl.Tests.Application;
+
+public class DummyContext : KafkaContext
+{
+    public DummyContext() : base() { }
+    public DummyContext(KafkaContextOptions options) : base(options) { }
+}
+
+public class KsqlContextBuilderTests
+{
+    [Fact]
+    public void Create_ReturnsBuilder()
+    {
+        var builder = KsqlContextBuilder.Create();
+        Assert.NotNull(builder);
+    }
+
+    [Fact]
+    public void BuildContext_CreatesInstance()
+    {
+        var ctx = KsqlContextBuilder.Create().UseSchemaRegistry("u").BuildContext<DummyContext>();
+        Assert.IsType<DummyContext>(ctx);
+    }
+}

--- a/tests/Application/KsqlContextOptionsExtensionsTests.cs
+++ b/tests/Application/KsqlContextOptionsExtensionsTests.cs
@@ -1,0 +1,52 @@
+using KsqlDsl.Application;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Application;
+
+public class KsqlContextOptionsExtensionsTests
+{
+    [Fact]
+    public void UseSchemaRegistry_WithUrl_ConfiguresClient()
+    {
+        var options = new KsqlContextOptions();
+        options.UseSchemaRegistry("http://localhost:8081");
+        Assert.NotNull(options.SchemaRegistryClient);
+    }
+
+    [Fact]
+    public void EnableLogging_SetsLoggerFactory()
+    {
+        var options = new KsqlContextOptions();
+        var factory = NullLoggerFactory.Instance;
+        options.EnableLogging(factory);
+        Assert.Equal(factory, options.LoggerFactory);
+    }
+
+    [Fact]
+    public void ConfigureValidation_UpdatesFlags()
+    {
+        var options = new KsqlContextOptions();
+        options.ConfigureValidation(autoRegister: false, failOnErrors: false, enablePreWarming: false);
+        Assert.False(options.AutoRegisterSchemas);
+        Assert.False(options.FailOnInitializationErrors);
+        Assert.False(options.EnableCachePreWarming);
+    }
+
+    [Fact]
+    public void WithTimeouts_SetsTimeout()
+    {
+        var options = new KsqlContextOptions();
+        var ts = System.TimeSpan.FromSeconds(5);
+        options.WithTimeouts(ts);
+        Assert.Equal(ts, options.SchemaRegistrationTimeout);
+    }
+
+    [Fact]
+    public void EnableDebugMode_SetsFlag()
+    {
+        var options = new KsqlContextOptions();
+        options.EnableDebugMode(true);
+        Assert.True(options.EnableDebugLogging);
+    }
+}

--- a/tests/Application/KsqlContextOptionsTests.cs
+++ b/tests/Application/KsqlContextOptionsTests.cs
@@ -1,0 +1,23 @@
+using KsqlDsl.Application;
+using Confluent.SchemaRegistry;
+using Xunit;
+
+namespace KsqlDsl.Tests.Application;
+
+public class KsqlContextOptionsTests
+{
+    [Fact]
+    public void Validate_WithMissingClient_Throws()
+    {
+        var options = new KsqlContextOptions { SchemaRegistryClient = null! };
+        var ex = Assert.Throws<InvalidOperationException>(() => options.Validate());
+        Assert.Contains("SchemaRegistryClient", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_WithNonPositiveTimeout_Throws()
+    {
+        var options = new KsqlContextOptions { SchemaRegistryClient = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = "url" }), SchemaRegistrationTimeout = System.TimeSpan.Zero };
+        Assert.Throws<InvalidOperationException>(() => options.Validate());
+    }
+}

--- a/tests/Configuration/AvroRetryPolicyTests.cs
+++ b/tests/Configuration/AvroRetryPolicyTests.cs
@@ -1,0 +1,21 @@
+using KsqlDsl.Configuration.Options;
+using Xunit;
+
+namespace KsqlDsl.Tests.Configuration;
+
+public class AvroRetryPolicyTests
+{
+    [Fact]
+    public void Validate_InvalidMaxAttempts_Throws()
+    {
+        var policy = new AvroRetryPolicy { MaxAttempts = 0 };
+        Assert.Throws<ArgumentException>(() => policy.Validate());
+    }
+
+    [Fact]
+    public void Validate_InvalidDelays_Throws()
+    {
+        var policy = new AvroRetryPolicy { InitialDelay = System.TimeSpan.Zero };
+        Assert.Throws<ArgumentException>(() => policy.Validate());
+    }
+}

--- a/tests/Core/CoreExtensionsTests.cs
+++ b/tests/Core/CoreExtensionsTests.cs
@@ -1,0 +1,48 @@
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Core.Extensions;
+using System.Reflection;
+using Xunit;
+
+namespace KsqlDsl.Tests.Core;
+
+public class CoreExtensionsTests
+{
+    private class Sample
+    {
+        [Key(Order = 1)]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void GetTopicName_ReturnsAttributeValue()
+    {
+        var model = new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicAttribute = new TopicAttribute("topic"),
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! },
+            AllProperties = typeof(Sample).GetProperties()
+        };
+        Assert.Equal("topic", model.GetTopicName());
+        Assert.True(model.HasKeys());
+        Assert.False(model.IsCompositeKey());
+        var ordered = model.GetOrderedKeyProperties();
+        Assert.Single(ordered);
+    }
+
+    [Fact]
+    public void TypeExtension_ReturnsTopicName()
+    {
+        Assert.Equal("Sample", typeof(Sample).GetKafkaTopicName());
+        Assert.True(typeof(Sample).HasKafkaKeys());
+    }
+
+    [Fact]
+    public void PropertyExtensions_DetectKey()
+    {
+        var prop = typeof(Sample).GetProperty(nameof(Sample.Id))!;
+        Assert.True(prop.IsKafkaKey());
+        Assert.Equal(1, prop.GetKeyOrder());
+    }
+}

--- a/tests/Messaging/PoolMetricsTests.cs
+++ b/tests/Messaging/PoolMetricsTests.cs
@@ -1,0 +1,14 @@
+using KsqlDsl.Messaging.Core;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class PoolMetricsTests
+{
+    [Fact]
+    public void FailureRate_ComputesCorrectly()
+    {
+        var metrics = new PoolMetrics { CreatedCount = 10, CreationFailures = 2 };
+        Assert.Equal(0.2, metrics.FailureRate, 3);
+    }
+}

--- a/tests/Serialization/AvroSchemaBuilderTests.cs
+++ b/tests/Serialization/AvroSchemaBuilderTests.cs
@@ -1,0 +1,30 @@
+using KsqlDsl.Serialization.Avro.Management;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaBuilderTests
+{
+    private class Sample
+    {
+        [KsqlDsl.Core.Abstractions.Key]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void GenerateKeySchema_ForSingleKey_ReturnsPrimitiveSchema()
+    {
+        var builder = new AvroSchemaBuilder();
+        var schema = builder.GenerateKeySchema<Sample>();
+        Assert.Contains("int", schema);
+    }
+
+    [Fact]
+    public void ValidateSchemaAsync_InvalidSchema_ReturnsFalse()
+    {
+        var builder = new AvroSchemaBuilder();
+        var result = builder.ValidateSchemaAsync("{ invalid }").Result;
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add new test suites under Application, Configuration, Core, Messaging and Serialization namespaces
- cover option extensions, retry policy, entity model extensions, metrics and Avro schema builder logic

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574aa55ab083278504636058132ad2