### PR TITLE
Add unit tests across remaining namespaces

### DIFF
--- a/tests/Configuration/KafkaBatchOptionsTests.cs
+++ b/tests/Configuration/KafkaBatchOptionsTests.cs
@@ -1,0 +1,19 @@
+using KsqlDsl.Configuration.Abstractions;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.Configuration;
+
+public class KafkaBatchOptionsTests
+{
+    [Fact]
+    public void Defaults_AreExpected()
+    {
+        var opts = new KafkaBatchOptions();
+        Assert.Equal(100, opts.MaxBatchSize);
+        Assert.Equal(TimeSpan.FromSeconds(30), opts.MaxWaitTime);
+        Assert.False(opts.EnableEmptyBatches);
+        Assert.True(opts.AutoCommit);
+        Assert.Null(opts.ConsumerGroupId);
+    }
+}

--- a/tests/EventSetTests.cs
+++ b/tests/EventSetTests.cs
@@ -1,0 +1,94 @@
+using KsqlDsl;
+using KsqlDsl.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace KsqlDsl.Tests;
+
+public class EventSetTests
+{
+    private class DummyContext : IKafkaContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class TestSet : EventSet<TestEntity>
+    {
+        private readonly List<TestEntity> _items;
+        public bool Sent { get; private set; }
+
+        public TestSet(List<TestEntity> items, EntityModel model) : base(new DummyContext(), model)
+        {
+            _items = items;
+        }
+
+        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken)
+        {
+            Sent = true;
+            return Task.CompletedTask;
+        }
+
+        protected override Task<List<TestEntity>> ExecuteQueryAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_items);
+        }
+    }
+
+    private static EntityModel CreateModel()
+    {
+        return new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            TopicAttribute = new TopicAttribute("test-topic"),
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! },
+            AllProperties = typeof(TestEntity).GetProperties()
+        };
+    }
+
+    [Fact]
+    public async Task AddAsync_NullEntity_Throws()
+    {
+        var set = new TestSet(new(), CreateModel());
+        await Assert.ThrowsAsync<ArgumentNullException>(() => set.AddAsync(null!));
+    }
+
+    [Fact]
+    public async Task ToListAsync_ReturnsItems()
+    {
+        var items = new List<TestEntity> { new TestEntity { Id = 1 } };
+        var set = new TestSet(items, CreateModel());
+        var result = await set.ToListAsync();
+        Assert.Single(result);
+        Assert.Equal(1, result[0].Id);
+    }
+
+    [Fact]
+    public async Task ForEachAsync_InvokesAction()
+    {
+        var items = new List<TestEntity> { new TestEntity { Id = 1 }, new TestEntity { Id = 2 } };
+        var set = new TestSet(items, CreateModel());
+        var sum = 0;
+        await set.ForEachAsync(e => { sum += e.Id; return Task.CompletedTask; });
+        Assert.Equal(3, sum);
+    }
+
+    [Fact]
+    public void Metadata_ReturnsExpectedValues()
+    {
+        var model = CreateModel();
+        var set = new TestSet(new(), model);
+        Assert.Equal("test-topic", set.GetTopicName());
+        Assert.Equal(model, set.GetEntityModel());
+        Assert.IsType<DummyContext>(set.GetContext());
+        var str = set.ToString();
+        Assert.Contains("EventSet<TestEntity>", str);
+        Assert.Contains("test-topic", str);
+    }
+}

--- a/tests/Messaging/KafkaBatchTests.cs
+++ b/tests/Messaging/KafkaBatchTests.cs
@@ -1,0 +1,34 @@
+using KsqlDsl.Messaging.Producers.Core;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class KafkaBatchTests
+{
+    [Fact]
+    public void IsEmpty_WhenNoMessages_ReturnsTrue()
+    {
+        var batch = new KafkaBatch<TestEntity, int>();
+        Assert.True(batch.IsEmpty);
+        Assert.Equal(0, batch.TotalMessages);
+    }
+
+    [Fact]
+    public void ProcessingTime_ComputedCorrectly()
+    {
+        var batch = new KafkaBatch<TestEntity, int>
+        {
+            BatchStartTime = new DateTime(2025,1,1,0,0,0,DateTimeKind.Utc),
+            BatchEndTime = new DateTime(2025,1,1,0,0,1,DateTimeKind.Utc)
+        };
+        Assert.Equal(TimeSpan.FromSeconds(1), batch.ProcessingTime);
+    }
+
+    [Fact]
+    public async Task CommitAsync_Completes()
+    {
+        var batch = new KafkaBatch<TestEntity, int>();
+        await batch.CommitAsync();
+    }
+}

--- a/tests/Messaging/KafkaConsumerManagerExceptionTests.cs
+++ b/tests/Messaging/KafkaConsumerManagerExceptionTests.cs
@@ -1,0 +1,18 @@
+using KsqlDsl.Messaging.Consumers.Exceptions;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class KafkaConsumerManagerExceptionTests
+{
+    [Fact]
+    public void Constructors_SetProperties()
+    {
+        var ex1 = new KafkaConsumerManagerException("msg");
+        Assert.Equal("msg", ex1.Message);
+        var inner = new Exception("inner");
+        var ex2 = new KafkaConsumerManagerException("m", inner);
+        Assert.Equal(inner, ex2.InnerException);
+    }
+}

--- a/tests/Serialization/AvroEntityConfigurationTests.cs
+++ b/tests/Serialization/AvroEntityConfigurationTests.cs
@@ -1,0 +1,50 @@
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroEntityConfigurationTests
+{
+    [Topic("orders")]
+    private class Order
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        [KafkaIgnore]
+        public string Debug { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void Constructor_AppliesAttributes()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Order));
+        Assert.Equal("orders", cfg.TopicName);
+        Assert.True(cfg.HasKeys());
+    }
+
+    [Fact]
+    public void GetSerializableProperties_ExcludesIgnored()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Order));
+        var props = cfg.GetSerializableProperties();
+        Assert.DoesNotContain(typeof(Order).GetProperty(nameof(Order.Debug))!, props);
+    }
+
+    [Fact]
+    public void DetermineKeyType_ReturnsPropertyType()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Order));
+        Assert.Equal(typeof(int), cfg.DetermineKeyType());
+    }
+
+    [Fact]
+    public void GetSummary_IncludesInfo()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Order));
+        var summary = cfg.GetSummary();
+        Assert.Contains("Order", summary);
+        Assert.Contains("orders", summary);
+    }
+}

--- a/tests/Serialization/AvroSchemaInfoTests.cs
+++ b/tests/Serialization/AvroSchemaInfoTests.cs
@@ -1,0 +1,36 @@
+using KsqlDsl.Serialization.Avro.Core;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaInfoTests
+{
+    [Fact]
+    public void HasCustomKey_And_KeyType_Work()
+    {
+        var info = new AvroSchemaInfo
+        {
+            EntityType = typeof(TestEntity),
+            TopicName = "t",
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! }
+        };
+        Assert.True(info.HasCustomKey);
+        Assert.Equal(typeof(int), info.KeyType);
+    }
+
+    [Fact]
+    public void ToString_ContainsInfo()
+    {
+        var info = new AvroSchemaInfo
+        {
+            EntityType = typeof(TestEntity),
+            TopicName = "topic",
+            KeySchemaId = 1,
+            ValueSchemaId = 2
+        };
+        var str = info.ToString();
+        Assert.Contains("topic", str);
+        Assert.Contains("1", str);
+        Assert.Contains("2", str);
+    }
+}


### PR DESCRIPTION
## Summary
- add EventSet unit tests for core KsqlDsl namespace
- add KafkaBatchOptions tests for configuration abstractions
- add producer and consumer related tests in messaging
- add Avro entity and schema info tests for serialization layer

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574c82230c8327a4e69b19c0b6e17e