### PR TITLE
Fix AvroSchemaBuilder async test

### DIFF
--- a/tests/Serialization/AvroSchemaBuilderTests.cs
+++ b/tests/Serialization/AvroSchemaBuilderTests.cs
@@ -21,10 +21,10 @@ public class AvroSchemaBuilderTests
     }
 
     [Fact]
-    public void ValidateSchemaAsync_InvalidSchema_ReturnsFalse()
+    public async Task ValidateSchemaAsync_InvalidSchema_ReturnsFalse()
     {
         var builder = new AvroSchemaBuilder();
-        var result = builder.ValidateSchemaAsync("{ invalid }").Result;
+        var result = await builder.ValidateSchemaAsync("{ invalid }");
         Assert.False(result);
     }
 }


### PR DESCRIPTION
## Summary
- fix `ValidateSchemaAsync_InvalidSchema_ReturnsFalse` to use async/await

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857504efb808327989fc29777708e6b