### PR TITLE
Fix csproj path and remove BOM

### DIFF
--- a/tests/KsqlDslTests.csproj
+++ b/tests/KsqlDslTests.csproj
@@ -1,4 +1,3 @@
-﻿
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>KsqlDsl.Tests</AssemblyName>
@@ -7,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\KsqlDsl.csproj" />
+    <ProjectReference Include="../src/KsqlDsl.csproj" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
## Summary
- fix project reference path and remove BOM in `tests/KsqlDslTests.csproj`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857565438408327a8b1c447bdd70534