### PR TITLE
Fix tests that used read-only properties

### DIFF
--- a/tests/Application/AvroSchemaInfoExtensionsTests.cs
+++ b/tests/Application/AvroSchemaInfoExtensionsTests.cs
@@ -18,7 +18,11 @@ public class AvroSchemaInfoExtensionsTests
     [Fact]
     public void GetStreamTableType_UsesHasCustomKey()
     {
-        var info = new AvroSchemaInfo { TopicName = "t", HasCustomKey = true };
+        var info = new AvroSchemaInfo
+        {
+            TopicName = "t",
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! }
+        };
         Assert.Equal("Table", info.GetStreamTableType());
     }
 
@@ -28,7 +32,6 @@ public class AvroSchemaInfoExtensionsTests
         var info = new AvroSchemaInfo
         {
             TopicName = "t",
-            HasCustomKey = true,
             KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))!, typeof(TestEntity).GetProperty(nameof(TestEntity.Name))! }
         };
         Assert.Equal("CompositeKey", info.GetKeyTypeName());

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace KsqlDsl.Tests.Application;
 
-public class DummyContext : KafkaContext
+public class DummyContext : KsqlDsl.Application.KafkaContext
 {
     public DummyContext() : base() { }
     public DummyContext(KafkaContextOptions options) : base(options) { }


### PR DESCRIPTION
## Summary
- adjust `AvroSchemaInfoExtensionsTests` to set `KeyProperties` instead of assigning to `HasCustomKey`
- disambiguate `DummyContext` inheritance in `KsqlContextBuilderTests`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685780561a2483279dadf872f5d73801