### PR TITLE
Address Kyoka report 20250622_131435

### DIFF
--- a/src/Application/KsqlContextBuilder.cs
+++ b/src/Application/KsqlContextBuilder.cs
@@ -65,6 +65,22 @@ public class KsqlContextBuilder
     public T BuildContext<T>() where T : KafkaContext
     {
         var options = Build();
+
+        // Prefer constructor with KsqlContextOptions if available
+        var ctor = typeof(T).GetConstructor(new[] { typeof(KsqlContextOptions) });
+        if (ctor != null)
+        {
+            return (T)ctor.Invoke(new object[] { options });
+        }
+
+        // Fallback to parameterless constructor
+        ctor = typeof(T).GetConstructor(Type.EmptyTypes);
+        if (ctor != null)
+        {
+            return (T)ctor.Invoke(null);
+        }
+
+        // Last resort: try original Activator (may throw)
         return (T)Activator.CreateInstance(typeof(T), options)!;
     }
 }

--- a/src/Query/Ksql/KsqlDbRestApiClient.cs
+++ b/src/Query/Ksql/KsqlDbRestApiClient.cs
@@ -287,7 +287,10 @@ internal class KsqlDbRestApiClient : IDisposable
         return element.ValueKind switch
         {
             JsonValueKind.String => element.GetString() ?? "",
-            JsonValueKind.Number => element.TryGetInt64(out var longVal) ? longVal : element.GetDouble(),
+            JsonValueKind.Number =>
+                element.TryGetInt32(out var intVal) ? intVal :
+                element.TryGetInt64(out var longVal) ? longVal :
+                element.GetDouble(),
             JsonValueKind.True => true,
             JsonValueKind.False => false,
             JsonValueKind.Null => null!,

--- a/src/Query/Pipeline/StreamTableAnalyzer.cs
+++ b/src/Query/Pipeline/StreamTableAnalyzer.cs
@@ -102,6 +102,9 @@ internal class StreamTableAnalyzer
 
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
+            // Visit inner call first to preserve the original LINQ method order
+            var visited = base.VisitMethodCall(node);
+
             var methodName = node.Method.Name;
             MethodCalls.Add(node);
 
@@ -143,7 +146,7 @@ internal class StreamTableAnalyzer
                 }
             }
 
-            return base.VisitMethodCall(node);
+            return visited;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix method traversal order in `StreamTableAnalyzer`
- improve numeric parsing in `KsqlDbRestApiClient`
- make `KsqlContextBuilder` more flexible when creating contexts

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685784c7745c8327b7a297be33f6fbf9