### PR TITLE
Fix failing test expectations

### DIFF
--- a/tests/Query/Ksql/KsqlDbRestApiClientTests.cs
+++ b/tests/Query/Ksql/KsqlDbRestApiClientTests.cs
@@ -26,7 +26,7 @@ public class KsqlDbRestApiClientTests
         var result = await client.ExecuteQueryAsync("select * from t");
         Assert.Single(result.Header);
         Assert.Single(result.Rows);
-        Assert.Equal(1, result.Rows[0]["ID"]);
+        Assert.Equal(1, System.Convert.ToInt32(result.Rows[0]["ID"]));
     }
 
     [Fact]

--- a/tests/Query/Pipeline/QueryExecutionPipelineTests.cs
+++ b/tests/Query/Pipeline/QueryExecutionPipelineTests.cs
@@ -43,7 +43,7 @@ public class QueryExecutionPipelineTests
 
         var ksql = pipeline.GenerateKsqlQuery("Base", expr, true);
 
-        Assert.Matches("^SELECT * FROM Base_stream_\\d+_stream_\\d+$", ksql);
+        Assert.Matches("^SELECT \\* FROM Base_stream_\\d+_stream_\\d+$", ksql);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class QueryExecutionPipelineTests
 
         var ksql = pipeline.GenerateKsqlQuery("Base", expr, false);
 
-        Assert.Matches("^SELECT * FROM Base_table_\\d+_table_\\d+ EMIT CHANGES$", ksql);
+        Assert.Matches("^SELECT \\* FROM Base_table_\\d+_table_\\d+ EMIT CHANGES$", ksql);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- escape wildcard characters in regex expectations
- normalize numeric comparison in API test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857885a8df4832786ced0464b529055