### PR TITLE
Add initial unit tests for uncovered classes

### DIFF
--- a/tests/Application/EventSetWithServicesTests.cs
+++ b/tests/Application/EventSetWithServicesTests.cs
@@ -1,0 +1,33 @@
+using KsqlDsl;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Core.Context;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Application;
+
+public class EventSetWithServicesTests
+{
+    private class TestContext : KafkaContext
+    {
+        public TestContext() : base() { }
+    }
+
+    [Fact]
+    public void Constructors_CreateInstances()
+    {
+        var ctx = new TestContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            TopicAttribute = new TopicAttribute("t"),
+            AllProperties = typeof(TestEntity).GetProperties(),
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! }
+        };
+        var set1 = new EventSetWithServices<TestEntity>(ctx, model);
+        Assert.NotNull(set1);
+        Expression expr = Expression.Constant(1);
+        var set2 = new EventSetWithServices<TestEntity>(ctx, model, expr);
+        Assert.NotNull(set2);
+    }
+}

--- a/tests/Application/KafkaContextTests.cs
+++ b/tests/Application/KafkaContextTests.cs
@@ -1,0 +1,53 @@
+using KsqlDsl;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Core.Context;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.Application;
+
+public class KafkaContextTests
+{
+    private class TestContext : KafkaContext
+    {
+        public TestContext() : base() { }
+        public TestContext(KafkaContextOptions opt) : base(opt) { }
+
+        public new IEntitySet<T> CallCreateEntitySet<T>(EntityModel model) where T : class
+            => base.CreateEntitySet<T>(model);
+
+        public new KafkaProducerManager CallGetProducerManager() => base.GetProducerManager();
+        public new KafkaConsumerManager CallGetConsumerManager() => base.GetConsumerManager();
+    }
+
+    [Fact]
+    public void Constructors_InitializeManagers()
+    {
+        var ctx = new TestContext();
+        Assert.NotNull(ctx.CallGetProducerManager());
+        Assert.NotNull(ctx.CallGetConsumerManager());
+        Assert.Contains("Core層統合", ctx.ToString());
+    }
+
+    [Fact]
+    public void CreateEntitySet_ReturnsEventSet()
+    {
+        var ctx = new TestContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(TestEntity),
+            TopicAttribute = new TopicAttribute("test-topic"),
+            KeyProperties = new[] { typeof(TestEntity).GetProperty(nameof(TestEntity.Id))! },
+            AllProperties = typeof(TestEntity).GetProperties()
+        };
+        var set = ctx.CallCreateEntitySet<TestEntity>(model);
+        Assert.IsType<EventSet<TestEntity>>(set);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow()
+    {
+        var ctx = new TestContext();
+        ctx.Dispose();
+    }
+}

--- a/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
+++ b/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
@@ -1,0 +1,40 @@
+using KsqlDsl.Serialization.Avro.Management;
+using KsqlDsl.Serialization.Abstractions;
+using KsqlDsl.Serialization.Avro.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaRegistrationServiceTests
+{
+    private class StubSchemaRegistryClient : ISchemaRegistryClient
+    {
+        public void Dispose() { }
+        public Task<(int keySchemaId, int valueSchemaId)> RegisterTopicSchemasAsync(string t, string k, string v) => Task.FromResult((1,2));
+        public Task<int> RegisterKeySchemaAsync(string t, string k) => Task.FromResult(1);
+        public Task<int> RegisterValueSchemaAsync(string t, string v) => Task.FromResult(2);
+        public Task<int> RegisterSchemaAsync(string s, string a) => Task.FromResult(1);
+        public Task<AvroSchemaInfo> GetLatestSchemaAsync(string s) => Task.FromResult(new AvroSchemaInfo());
+        public Task<AvroSchemaInfo> GetSchemaByIdAsync(int id) => Task.FromResult(new AvroSchemaInfo());
+        public Task<bool> CheckCompatibilityAsync(string s, string a) => Task.FromResult(true);
+        public Task<IList<int>> GetSchemaVersionsAsync(string s) => Task.FromResult<IList<int>>(new List<int>());
+        public Task<AvroSchemaInfo> GetSchemaAsync(string s, int v) => Task.FromResult(new AvroSchemaInfo());
+        public Task<IList<string>> GetAllSubjectsAsync() => Task.FromResult<IList<string>>(new List<string>());
+    }
+
+    [Fact]
+    public void GetSchemaInfoAsync_ReturnsStoredInfo()
+    {
+        var service = new AvroSchemaRegistrationService(new StubSchemaRegistryClient(), NullLoggerFactory.Instance);
+        var field = typeof(AvroSchemaRegistrationService).GetField("_registeredSchemas", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var dict = (Dictionary<Type, AvroSchemaInfo>)field.GetValue(service)!;
+        var info = new AvroSchemaInfo { EntityType = typeof(TestEntity), TopicName = "t" };
+        dict[typeof(TestEntity)] = info;
+        var result = service.GetSchemaInfoAsync<TestEntity>();
+        Assert.Equal(info, result);
+    }
+}

--- a/tests/Serialization/AvroSchemaRepositoryTests.cs
+++ b/tests/Serialization/AvroSchemaRepositoryTests.cs
@@ -1,0 +1,23 @@
+using KsqlDsl.Serialization.Avro.Management;
+using KsqlDsl.Serialization.Avro.Core;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaRepositoryTests
+{
+    [Fact]
+    public void StoreAndRetrieve_Works()
+    {
+        var repo = new AvroSchemaRepository();
+        var info = new AvroSchemaInfo { EntityType = typeof(TestEntity), TopicName = "t" };
+        repo.StoreSchemaInfo(info);
+        Assert.Same(info, repo.GetSchemaInfo(typeof(TestEntity)));
+        Assert.Same(info, repo.GetSchemaInfoByTopic("t"));
+        Assert.Single(repo.GetAllSchemas());
+        Assert.True(repo.IsRegistered(typeof(TestEntity)));
+        repo.Clear();
+        Assert.Empty(repo.GetAllSchemas());
+    }
+}

--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -1,0 +1,66 @@
+using KsqlDsl.Configuration.Options;
+using KsqlDsl.Serialization.Abstractions;
+using KsqlDsl.Serialization.Avro;
+using KsqlDsl.Serialization.Avro.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class ResilientAvroSerializerManagerTests
+{
+    private class StubSchemaRegistryClient : ISchemaRegistryClient
+    {
+        public void Dispose() { }
+        public Task<(int keySchemaId, int valueSchemaId)> RegisterTopicSchemasAsync(string t, string k, string v) => Task.FromResult((1,2));
+        public Task<int> RegisterKeySchemaAsync(string t, string k) => Task.FromResult(1);
+        public Task<int> RegisterValueSchemaAsync(string t, string v) => Task.FromResult(2);
+        public Task<int> RegisterSchemaAsync(string s, string a) => Task.FromResult(1);
+        public Task<AvroSchemaInfo> GetLatestSchemaAsync(string s) => Task.FromResult(new AvroSchemaInfo());
+        public Task<AvroSchemaInfo> GetSchemaByIdAsync(int id) => Task.FromResult(new AvroSchemaInfo());
+        public Task<bool> CheckCompatibilityAsync(string s, string a) => Task.FromResult(true);
+        public Task<IList<int>> GetSchemaVersionsAsync(string s) => Task.FromResult<IList<int>>(new List<int>());
+        public Task<AvroSchemaInfo> GetSchemaAsync(string s, int v) => Task.FromResult(new AvroSchemaInfo());
+        public Task<IList<string>> GetAllSubjectsAsync() => Task.FromResult<IList<string>>(new List<string>());
+    }
+
+    private static ResilientAvroSerializerManager CreateManager()
+    {
+        var options = Options.Create(new AvroOperationRetrySettings());
+        return new ResilientAvroSerializerManager(new StubSchemaRegistryClient(), options, NullLogger<ResilientAvroSerializerManager>.Instance);
+    }
+
+    [Fact]
+    public void ExtractTopicFromSubject_ReturnsTopic()
+    {
+        var mgr = CreateManager();
+        var method = typeof(ResilientAvroSerializerManager).GetMethod("ExtractTopicFromSubject", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var result = method.Invoke(mgr, new object[] { "orders-value" });
+        Assert.Equal("orders", result);
+    }
+
+    [Fact]
+    public void ShouldRetry_EvaluatesPolicy()
+    {
+        var mgr = CreateManager();
+        var method = typeof(ResilientAvroSerializerManager).GetMethod("ShouldRetry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var policy = new AvroRetryPolicy { MaxAttempts = 3, RetryableExceptions = { typeof(TimeoutException) } };
+        var can = (bool)method.Invoke(mgr, new object[] { new TimeoutException(), policy, 1 })!;
+        Assert.True(can);
+        var cannot = (bool)method.Invoke(mgr, new object[] { new InvalidOperationException(), policy, 1 })!;
+        Assert.False(cannot);
+    }
+
+    [Fact]
+    public void CalculateDelay_RespectsMax()
+    {
+        var mgr = CreateManager();
+        var method = typeof(ResilientAvroSerializerManager).GetMethod("CalculateDelay", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var policy = new AvroRetryPolicy { InitialDelay = TimeSpan.FromMilliseconds(100), BackoffMultiplier = 2, MaxDelay = TimeSpan.FromMilliseconds(150) };
+        var delay = (TimeSpan)method.Invoke(mgr, new object[] { policy, 2 })!;
+        Assert.Equal(TimeSpan.FromMilliseconds(150), delay);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `KafkaContext` and `EventSetWithServices`
- cover private helpers of `ResilientAvroSerializerManager`
- test `AvroSchemaRegistrationService` and `AvroSchemaRepository`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a391acdc8327a8c8513f1f36cd18