### PR TITLE
Fix KafkaContext test for EventSetWithServices

### DIFF
--- a/tests/Application/KafkaContextTests.cs
+++ b/tests/Application/KafkaContextTests.cs
@@ -42,7 +42,7 @@ public class KafkaContextTests
             AllProperties = typeof(TestEntity).GetProperties()
         };
         var set = ctx.CallCreateEntitySet<TestEntity>(model);
-        Assert.IsType<EventSet<TestEntity>>(set);
+        Assert.IsType<EventSetWithServices<TestEntity>>(set);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update `CreateEntitySet_ReturnsEventSet` to expect `EventSetWithServices`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a822f14883279e66373cd2707650