### PR TITLE
Add unit tests for producer manager and Avro serializer

### DIFF
--- a/tests/Messaging/KafkaProducerManagerTests.cs
+++ b/tests/Messaging/KafkaProducerManagerTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Confluent.Kafka;
+using KsqlDsl.Configuration;
+using KsqlDsl.Messaging.Configuration;
+using KsqlDsl.Messaging.Producers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class KafkaProducerManagerTests
+{
+    private class SampleEntity
+    {
+        [KsqlDsl.Core.Abstractions.Key]
+        public int Id { get; set; }
+    }
+
+    private static T InvokePrivate<T>(object obj, string name, params object[]? args)
+    {
+        var method = obj.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (T)method.Invoke(obj, args)!;
+    }
+
+    [Fact]
+    public void BuildProducerConfig_ReturnsConfiguredValues()
+    {
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "server", ClientId = "cid" },
+            Topics = new Dictionary<string, TopicSection>
+            {
+                ["topic"] = new TopicSection
+                {
+                    Producer = new ProducerSection
+                    {
+                        Acks = "All",
+                        CompressionType = "Gzip",
+                        EnableIdempotence = false,
+                        MaxInFlightRequestsPerConnection = 2,
+                        LingerMs = 10,
+                        BatchSize = 1000,
+                        RetryBackoffMs = 200
+                    }
+                }
+            }
+        };
+        var manager = new KafkaProducerManager(Options.Create(options), new NullLoggerFactory());
+        var config = InvokePrivate<ProducerConfig>(manager, "BuildProducerConfig", "topic");
+
+        Assert.Equal("server", config.BootstrapServers);
+        Assert.Equal("cid", config.ClientId);
+        Assert.Equal(Acks.All, config.Acks);
+        Assert.Equal(CompressionType.Gzip, config.CompressionType);
+        Assert.False(config.EnableIdempotence);
+        Assert.Equal(2, config.MaxInFlight);
+        Assert.Equal(10, config.LingerMs);
+        Assert.Equal(1000, config.BatchSize);
+        Assert.Equal(200, config.RetryBackoffMs);
+    }
+
+    [Fact]
+    public void GetOrCreateSerializationManager_CachesInstance()
+    {
+        var options = new KsqlDslOptions();
+        var manager = (KafkaProducerManager)FormatterServices.GetUninitializedObject(typeof(KafkaProducerManager));
+        typeof(KafkaProducerManager).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, options);
+        typeof(KafkaProducerManager).GetField("_loggerFactory", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new NullLoggerFactory());
+        typeof(KafkaProducerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
+        typeof(KafkaProducerManager).GetField("_schemaRegistryClient", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager,
+            new Lazy<Confluent.SchemaRegistry.ISchemaRegistryClient>(() => null!));
+
+        var first = InvokePrivate<object>(manager, "GetOrCreateSerializationManager", typeof(SampleEntity));
+        var second = InvokePrivate<object>(manager, "GetOrCreateSerializationManager", typeof(SampleEntity));
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetEntityModel_ReturnsModelWithAttributes()
+    {
+        var manager = (KafkaProducerManager)FormatterServices.GetUninitializedObject(typeof(KafkaProducerManager));
+        typeof(KafkaProducerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
+        var model = InvokePrivate<KsqlDsl.Core.Abstractions.EntityModel>(manager, "GetEntityModel", typeof(SampleEntity));
+        Assert.Equal(typeof(SampleEntity), model.EntityType);
+        Assert.Single(model.KeyProperties);
+        Assert.Equal("SampleEntity", model.TopicAttribute?.TopicName ?? model.EntityType.Name);
+    }
+}

--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
+using KsqlDsl.Configuration.Options;
+using KsqlDsl.Serialization.Avro;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class ResilientAvroSerializerManagerTests
+{
+    private static T InvokePrivate<T>(object obj, string name, params object[]? args)
+    {
+        var method = obj.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (T)method.Invoke(obj, args)!;
+    }
+
+    private static ResilientAvroSerializerManager CreateUninitialized()
+    {
+        var mgr = (ResilientAvroSerializerManager)FormatterServices.GetUninitializedObject(typeof(ResilientAvroSerializerManager));
+        typeof(ResilientAvroSerializerManager).GetField("_logger", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(mgr, NullLogger<ResilientAvroSerializerManager>.Instance);
+        return mgr;
+    }
+
+    [Theory]
+    [InlineData("topic-key", "topic")]
+    [InlineData("topic-value", "topic")]
+    [InlineData("name", "name")]
+    public void ExtractTopicFromSubject_ReturnsTopic(string subject, string expected)
+    {
+        var mgr = CreateUninitialized();
+        var result = InvokePrivate<string>(mgr, "ExtractTopicFromSubject", subject);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ShouldRetry_RespectsPolicy()
+    {
+        var mgr = CreateUninitialized();
+        var policy = new AvroRetryPolicy { MaxAttempts = 3, RetryableExceptions = { typeof(TimeoutException) } };
+        var ex = new TimeoutException();
+        var result = InvokePrivate<bool>(mgr, "ShouldRetry", ex, policy, 1);
+        Assert.True(result);
+        Assert.False(InvokePrivate<bool>(mgr, "ShouldRetry", ex, policy, 3));
+    }
+
+    [Fact]
+    public void CalculateDelay_AppliesBackoff()
+    {
+        var mgr = CreateUninitialized();
+        var policy = new AvroRetryPolicy
+        {
+            InitialDelay = TimeSpan.FromMilliseconds(100),
+            BackoffMultiplier = 2,
+            MaxDelay = TimeSpan.FromMilliseconds(500)
+        };
+        var delay1 = InvokePrivate<TimeSpan>(mgr, "CalculateDelay", policy, 1);
+        var delay2 = InvokePrivate<TimeSpan>(mgr, "CalculateDelay", policy, 3);
+        Assert.Equal(TimeSpan.FromMilliseconds(100), delay1);
+        Assert.Equal(TimeSpan.FromMilliseconds(400), delay2);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for private producer manager helpers
- add tests for resilient Avro serializer manager

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857dd255618832798b512431d0afdc5