### PR TITLE
Fix generic reflection invocation in tests

### DIFF
--- a/tests/Messaging/KafkaProducerManagerTests.cs
+++ b/tests/Messaging/KafkaProducerManagerTests.cs
@@ -24,6 +24,28 @@ public class KafkaProducerManagerTests
     private static T InvokePrivate<T>(object obj, string name, params object[]? args)
     {
         var method = obj.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        if (method.ContainsGenericParameters)
+        {
+            var genericArgs = new List<Type>();
+            var invokeArgs = new List<object?>();
+
+            foreach (var arg in args ?? Array.Empty<object?>())
+            {
+                if (arg is Type type && genericArgs.Count < method.GetGenericArguments().Length)
+                {
+                    genericArgs.Add(type);
+                }
+                else
+                {
+                    invokeArgs.Add(arg);
+                }
+            }
+
+            method = method.MakeGenericMethod(genericArgs.ToArray());
+            args = invokeArgs.ToArray();
+        }
+
         return (T)method.Invoke(obj, args)!;
     }
 


### PR DESCRIPTION
## Summary
- improve `InvokePrivate` helper in `KafkaProducerManagerTests` so it can invoke generic private methods

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857debe70e88327bf6337d716ddee23