### PR TITLE
Fix InvokePrivate for generic private methods

### DIFF
--- a/tests/Messaging/KafkaProducerManagerTests.cs
+++ b/tests/Messaging/KafkaProducerManagerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Linq;
 using Confluent.Kafka;
 using KsqlDsl.Configuration;
 using KsqlDsl.Messaging.Configuration;
@@ -24,6 +25,14 @@ public class KafkaProducerManagerTests
     private static T InvokePrivate<T>(object obj, string name, params object[]? args)
     {
         var method = obj.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        if (method.IsGenericMethodDefinition)
+        {
+            var genericType = (Type)args![0];
+            method = method.MakeGenericMethod(genericType);
+            args = args.Skip(1).ToArray();
+        }
+
         return (T)method.Invoke(obj, args)!;
     }
 

--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using KsqlDsl.Configuration.Options;
 using KsqlDsl.Serialization.Avro;
@@ -13,6 +14,14 @@ public class ResilientAvroSerializerManagerTests
     private static T InvokePrivate<T>(object obj, string name, params object[]? args)
     {
         var method = obj.GetType().GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        if (method.IsGenericMethodDefinition)
+        {
+            var genericType = (Type)args![0];
+            method = method.MakeGenericMethod(genericType);
+            args = args.Skip(1).ToArray();
+        }
+
         return (T)method.Invoke(obj, args)!;
     }
 


### PR DESCRIPTION
## Summary
- handle generic methods in InvokePrivate helper in tests
- add `System.Linq` namespaces to use `Skip`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e3139c30832782fc56ee351cec69