### PR TITLE
Fix KafkaProducerManager test for schema registry

### DIFF
--- a/tests/Messaging/KafkaProducerManagerTests.cs
+++ b/tests/Messaging/KafkaProducerManagerTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
 using Confluent.Kafka;
+using Confluent.SchemaRegistry;
 using KsqlDsl.Configuration;
 using KsqlDsl.Messaging.Configuration;
 using KsqlDsl.Messaging.Producers;
@@ -84,7 +85,8 @@ public class KafkaProducerManagerTests
         typeof(KafkaProducerManager).GetField("_loggerFactory", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new NullLoggerFactory());
         typeof(KafkaProducerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
         typeof(KafkaProducerManager).GetField("_schemaRegistryClient", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager,
-            new Lazy<Confluent.SchemaRegistry.ISchemaRegistryClient>(() => null!));
+            new Lazy<Confluent.SchemaRegistry.ISchemaRegistryClient>(() =>
+                new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = "localhost" })));
 
         var first = InvokePrivate<object>(manager, "GetOrCreateSerializationManager", new[] { typeof(SampleEntity) });
         var second = InvokePrivate<object>(manager, "GetOrCreateSerializationManager", new[] { typeof(SampleEntity) });


### PR DESCRIPTION
## Summary
- add Schema Registry using statement
- provide a non-null Schema Registry client in the KafkaProducerManager test

## Testing
- `dotnet test tests/KsqlDslTests.csproj --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e7c77870832795ff49863b655b52