### PR TITLE
Add UnifiedSchemaGenerator tests

### DIFF
--- a/src/Core/Abstractions/DateTimeFormatAttribute.cs
+++ b/src/Core/Abstractions/DateTimeFormatAttribute.cs
@@ -1,14 +1,17 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace KsqlDsl.Core.Abstractions;
+
 [AttributeUsage(AttributeTargets.Property)]
 public class DateTimeFormatAttribute : Attribute
 {
+    [SetsRequiredMembers]
     public DateTimeFormatAttribute(string format = "yyyy-MM-dd HH:mm:ss")
     {
         Format = format ?? throw new ArgumentNullException(nameof(format));
     }
+
     public required string Format { get; set; }
     public string? Region { get; set; }
-
 }

--- a/tests/JsonAssert.cs
+++ b/tests/JsonAssert.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Xunit;
+
+namespace KsqlDsl.Tests;
+
+public static class JsonAssert
+{
+    public static void Equal(string expected, string actual)
+    {
+        using var docExpected = JsonDocument.Parse(expected);
+        using var docActual = JsonDocument.Parse(actual);
+        Assert.True(JsonElementEquals(docExpected.RootElement, docActual.RootElement),
+            $"Expected JSON does not match actual.\nExpected: {expected}\nActual: {actual}");
+    }
+
+    private static bool JsonElementEquals(JsonElement a, JsonElement b)
+    {
+        if (a.ValueKind != b.ValueKind)
+            return false;
+
+        return a.ValueKind switch
+        {
+            JsonValueKind.Object => ObjectsEqual(a, b),
+            JsonValueKind.Array => ArraysEqual(a, b),
+            JsonValueKind.String => string.Equals(a.GetString(), b.GetString(), StringComparison.OrdinalIgnoreCase),
+            JsonValueKind.Number => a.GetDouble() == b.GetDouble(),
+            JsonValueKind.True or JsonValueKind.False => a.GetBoolean() == b.GetBoolean(),
+            JsonValueKind.Null => true,
+            _ => string.Equals(a.ToString(), b.ToString(), StringComparison.OrdinalIgnoreCase)
+        };
+    }
+
+    private static bool ObjectsEqual(JsonElement a, JsonElement b)
+    {
+        var dictA = a.EnumerateObject().ToDictionary(p => p.Name, p => p.Value, StringComparer.OrdinalIgnoreCase);
+        var dictB = b.EnumerateObject().ToDictionary(p => p.Name, p => p.Value, StringComparer.OrdinalIgnoreCase);
+        if (dictA.Count != dictB.Count)
+            return false;
+        foreach (var kvp in dictA)
+        {
+            if (!dictB.TryGetValue(kvp.Key, out var other))
+                return false;
+            if (!JsonElementEquals(kvp.Value, other))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool ArraysEqual(JsonElement a, JsonElement b)
+    {
+        if (a.GetArrayLength() != b.GetArrayLength())
+            return false;
+        for (int i = 0; i < a.GetArrayLength(); i++)
+        {
+            if (!JsonElementEquals(a[i], b[i]))
+                return false;
+        }
+        return true;
+    }
+}

--- a/tests/JsonAssertTests.cs
+++ b/tests/JsonAssertTests.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace KsqlDsl.Tests;
+
+public class JsonAssertTests
+{
+    [Fact]
+    public void Equal_IgnoresFormattingAndCase()
+    {
+        var expected = "{\n  \"Name\": \"Alice\", \"Age\": 30 }";
+        var actual = "{ \"name\":\n\"alice\",\n\"age\":30 }";
+        JsonAssert.Equal(expected, actual);
+    }
+}

--- a/tests/PrivateAccessor.cs
+++ b/tests/PrivateAccessor.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+
+namespace KsqlDsl.Tests;
+
+internal static class PrivateAccessor
+{
+    internal static object InvokePrivate(
+        object target,
+        string name,
+        Type[] parameterTypes,
+        Type[]? genericTypes = null,
+        params object?[]? args)
+    {
+        var type = target as Type ?? target.GetType();
+        var flags = BindingFlags.NonPublic | (target is Type ? BindingFlags.Static : BindingFlags.Instance);
+        var method = type.GetMethod(name, flags, binder: null, types: parameterTypes, modifiers: null);
+        if (method == null)
+            throw new ArgumentException($"Method '{name}' with specified parameters not found on type '{type.FullName}'.");
+        if (genericTypes != null && method.IsGenericMethodDefinition)
+        {
+            method = method.MakeGenericMethod(genericTypes);
+        }
+        return method.Invoke(target is Type ? null : target, args);
+    }
+
+    internal static T InvokePrivate<T>(
+        object target,
+        string name,
+        Type[] parameterTypes,
+        Type[]? genericTypes = null,
+        params object?[]? args) => (T)InvokePrivate(target, name, parameterTypes, genericTypes, args)!;
+}

--- a/tests/Serialization/UnifiedSchemaGeneratorTests.cs
+++ b/tests/Serialization/UnifiedSchemaGeneratorTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using KsqlDsl.Configuration.Abstractions;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Avro.Core;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class UnifiedSchemaGeneratorTests
+{
+    private class SampleEntity
+    {
+        [Key(1)]
+        public int Id { get; set; }
+        [Key(2)]
+        public Guid GuidKey { get; set; }
+        public string? Name { get; set; }
+        public int? OptionalNumber { get; set; }
+        [DecimalPrecision(10,2)]
+        public decimal Price { get; set; }
+        [DateTimeFormat("date")]
+        public DateTime Date { get; set; }
+        [KafkaIgnore]
+        public string Ignore { get; set; } = string.Empty;
+    }
+
+    private static object InvokePrivate(string name, params object[]? args)
+    {
+        var method = typeof(UnifiedSchemaGenerator).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)!;
+        return method.Invoke(null, args);
+    }
+
+    private static T InvokePrivate<T>(string name, params object[]? args) => (T)InvokePrivate(name, args)!;
+
+    [Fact]
+    public void ToPascalCase_Works_WithVariousDelimiters()
+    {
+        var result = InvokePrivate<string>("ToPascalCase", "sample_topic-name.text");
+        Assert.Equal("SampleTopicNameText", result);
+        Assert.Equal(string.Empty, InvokePrivate<string>("ToPascalCase", ""));
+    }
+
+    [Fact]
+    public void IsPrimitiveType_KnownTypes()
+    {
+        Assert.True(InvokePrivate<bool>("IsPrimitiveType", typeof(string)));
+        Assert.False(InvokePrivate<bool>("IsPrimitiveType", typeof(DateTime)));
+    }
+
+    [Fact]
+    public void IsNullableProperty_DetectsNullableCorrectly()
+    {
+        var props = typeof(SampleEntity).GetProperties();
+        Assert.False(InvokePrivate<bool>("IsNullableProperty", props.First(p => p.Name == nameof(SampleEntity.Id))));
+        Assert.True(InvokePrivate<bool>("IsNullableProperty", props.First(p => p.Name == nameof(SampleEntity.OptionalNumber))));
+        Assert.True(InvokePrivate<bool>("IsNullableProperty", props.First(p => p.Name == nameof(SampleEntity.Name))));
+    }
+
+    [Fact]
+    public void GetSerializableProperties_ExcludesIgnored()
+    {
+        var props = InvokePrivate<PropertyInfo[]>("GetSerializableProperties", typeof(SampleEntity));
+        Assert.DoesNotContain(props, p => p.Name == nameof(SampleEntity.Ignore));
+        Assert.Contains(props, p => p.Name == nameof(SampleEntity.Name));
+    }
+
+    [Fact]
+    public void GetIgnoredProperties_ReturnsIgnored()
+    {
+        var props = InvokePrivate<PropertyInfo[]>("GetIgnoredProperties", typeof(SampleEntity));
+        Assert.Single(props);
+        Assert.Equal(nameof(SampleEntity.Ignore), props[0].Name);
+    }
+
+    [Fact]
+    public void MapPropertyToAvroType_HandlesNullable()
+    {
+        var prop = typeof(SampleEntity).GetProperty(nameof(SampleEntity.Name))!;
+        var result = InvokePrivate<object>("MapPropertyToAvroType", prop);
+        Assert.IsType<object[]>(result);
+    }
+
+    [Fact]
+    public void GetAvroType_MapsSpecialTypes()
+    {
+        var price = typeof(SampleEntity).GetProperty(nameof(SampleEntity.Price))!;
+        var avro = InvokePrivate<object>("GetAvroType", price);
+        var json = JsonSerializer.Serialize(avro);
+        Assert.Contains("logicalType", json);
+        var dtProp = typeof(SampleEntity).GetProperty(nameof(SampleEntity.Date))!;
+        avro = InvokePrivate<object>("GetAvroType", dtProp);
+        json = JsonSerializer.Serialize(avro);
+        Assert.Contains("date", json);
+    }
+
+    [Fact]
+    public void GeneratePrimitiveKeySchema_PrimitiveTypes()
+    {
+        var schema = InvokePrivate<string>("GeneratePrimitiveKeySchema", typeof(int));
+        Assert.Equal("\"int\"", schema);
+        schema = InvokePrivate<string>("GeneratePrimitiveKeySchema", typeof(Guid));
+        Assert.Contains("uuid", schema);
+    }
+
+    [Fact]
+    public void GenerateNullablePrimitiveKeySchema_PrimitiveTypes()
+    {
+        var schema = InvokePrivate<string>("GenerateNullablePrimitiveKeySchema", typeof(int));
+        Assert.Contains("null", schema);
+        schema = InvokePrivate<string>("GenerateNullablePrimitiveKeySchema", typeof(Guid));
+        Assert.Contains("uuid", schema);
+    }
+
+    [Fact]
+    public void GenerateCompositeKeySchema_BuildsRecord()
+    {
+        var keys = new[]
+        {
+            typeof(SampleEntity).GetProperty(nameof(SampleEntity.Id))!,
+            typeof(SampleEntity).GetProperty(nameof(SampleEntity.GuidKey))!
+        };
+        var json = InvokePrivate<string>("GenerateCompositeKeySchema", keys);
+        Assert.Contains("CompositeKey", json);
+        Assert.Contains("id", json);
+        Assert.Contains("guidKey", json);
+    }
+
+    [Fact]
+    public void GenerateFields_CreatesFields()
+    {
+        var fields = InvokePrivate<List<AvroField>>("GenerateFields", typeof(SampleEntity));
+        Assert.Contains(fields, f => f.Name == nameof(SampleEntity.Name));
+        Assert.DoesNotContain(fields, f => f.Name == nameof(SampleEntity.Ignore));
+    }
+
+    [Fact]
+    public void GenerateFieldsFromConfiguration_UsesConfiguration()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(SampleEntity));
+        var fields = InvokePrivate<List<AvroField>>("GenerateFieldsFromConfiguration", cfg);
+        Assert.Contains(fields, f => f.Name == nameof(SampleEntity.Id));
+    }
+
+    [Fact]
+    public void SerializeSchema_WorksWithOptions()
+    {
+        var schema = new AvroSchema { Type = "record", Name = "R" };
+        var json = InvokePrivate<string>("SerializeSchema", schema);
+        Assert.Contains("\"type\":\"record\"", json);
+        var opts = new SchemaGenerationOptions { PrettyFormat = false, UseKebabCase = true };
+        json = InvokePrivate<string>("SerializeSchema", schema, opts);
+        Assert.Contains("type", json);
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesValidSchema()
+    {
+        var json = UnifiedSchemaGenerator.GenerateSchema(typeof(SampleEntity));
+        Assert.True(UnifiedSchemaGenerator.ValidateSchema(json));
+    }
+
+    [Fact]
+    public void GenerateKeySchema_PrimitiveAndComplex()
+    {
+        var primitive = UnifiedSchemaGenerator.GenerateKeySchema(typeof(int));
+        Assert.Equal("\"int\"", primitive);
+        var complex = UnifiedSchemaGenerator.GenerateKeySchema(typeof(SampleEntity));
+        Assert.Contains("record", complex);
+    }
+
+    [Fact]
+    public void GenerateKeySchema_FromConfiguration()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(SampleEntity))
+        {
+            KeyProperties = new[]
+            {
+                typeof(SampleEntity).GetProperty(nameof(SampleEntity.Id))!,
+                typeof(SampleEntity).GetProperty(nameof(SampleEntity.GuidKey))!
+            }
+        };
+        var json = UnifiedSchemaGenerator.GenerateKeySchema(cfg);
+        Assert.Contains("CompositeKey", json);
+    }
+
+    [Fact]
+    public void GenerateValueSchema_UsesEntityType()
+    {
+        var json = UnifiedSchemaGenerator.GenerateValueSchema(typeof(SampleEntity));
+        Assert.Contains("record", json);
+    }
+
+    [Fact]
+    public void GenerateTopicSchemas_ReturnsPair()
+    {
+        var pair = UnifiedSchemaGenerator.GenerateTopicSchemas<int, SampleEntity>();
+        Assert.True(UnifiedSchemaGenerator.ValidateSchema(pair.keySchema));
+        Assert.True(UnifiedSchemaGenerator.ValidateSchema(pair.valueSchema));
+    }
+
+    [Fact]
+    public void GenerateTopicSchemas_WithName_UsesCustomName()
+    {
+        var pair = UnifiedSchemaGenerator.GenerateTopicSchemas<int, SampleEntity>("custom-topic");
+        Assert.Contains("Custom-topic_value", UnifiedSchemaGenerator.GenerateSchema(typeof(SampleEntity), new SchemaGenerationOptions { CustomName = "Custom-topic_value" }));
+        Assert.True(UnifiedSchemaGenerator.ValidateSchema(pair.valueSchema));
+    }
+
+    [Fact]
+    public void GetGenerationStats_ReturnsCounts()
+    {
+        var stats = UnifiedSchemaGenerator.GetGenerationStats(typeof(SampleEntity));
+        Assert.True(stats.TotalProperties >= 1);
+        Assert.Contains(nameof(SampleEntity.Ignore), stats.IgnoredPropertyNames);
+    }
+
+    [Fact]
+    public void ValidateSchema_WorksForVariousInputs()
+    {
+        Assert.False(UnifiedSchemaGenerator.ValidateSchema(""));
+        Assert.True(UnifiedSchemaGenerator.ValidateSchema("\"string\""));
+        Assert.False(UnifiedSchemaGenerator.ValidateSchema("{ invalid }"));
+    }
+}
+

--- a/tests/Serialization/UnifiedSchemaGeneratorTests.cs
+++ b/tests/Serialization/UnifiedSchemaGeneratorTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using KsqlDsl.Configuration.Abstractions;
 using KsqlDsl.Core.Abstractions;
 using KsqlDsl.Serialization.Avro.Core;
+using KsqlDsl.Serialization.Abstractions;
 using Xunit;
 
 namespace KsqlDsl.Tests.Serialization;


### PR DESCRIPTION
## Summary
- add coverage for Avro schema generation helpers in `UnifiedSchemaGenerator`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857ebc87c9c8327af9ab8f2d25fbc09