### PR TITLE
Fix required member warning for DateTimeFormatAttribute

### DIFF
--- a/src/Core/Abstractions/DateTimeFormatAttribute.cs
+++ b/src/Core/Abstractions/DateTimeFormatAttribute.cs
@@ -1,14 +1,17 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace KsqlDsl.Core.Abstractions;
+
 [AttributeUsage(AttributeTargets.Property)]
 public class DateTimeFormatAttribute : Attribute
 {
+    [SetsRequiredMembers]
     public DateTimeFormatAttribute(string format = "yyyy-MM-dd HH:mm:ss")
     {
         Format = format ?? throw new ArgumentNullException(nameof(format));
     }
+
     public required string Format { get; set; }
     public string? Region { get; set; }
-
 }


### PR DESCRIPTION
## Summary
- add `SetsRequiredMembers` attribute to the `DateTimeFormatAttribute` constructor

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f2d401908327912ba3d27ef85d61