### PR TITLE
Fix missing namespace in unified schema tests

### DIFF
--- a/tests/Serialization/UnifiedSchemaGeneratorTests.cs
+++ b/tests/Serialization/UnifiedSchemaGeneratorTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using KsqlDsl.Configuration.Abstractions;
 using KsqlDsl.Core.Abstractions;
 using KsqlDsl.Serialization.Avro.Core;
+using KsqlDsl.Serialization.Abstractions;
 using Xunit;
 
 namespace KsqlDsl.Tests.Serialization;


### PR DESCRIPTION
## Summary
- include `KsqlDsl.Serialization.Abstractions` in `UnifiedSchemaGeneratorTests`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f3efd3d48327b32c08e7ccd39e18