### PR TITLE
Fix SchemaRegistryClientWrapperTests type mismatch

### DIFF
--- a/tests/Serialization/SchemaRegistryClientWrapperTests.cs
+++ b/tests/Serialization/SchemaRegistryClientWrapperTests.cs
@@ -15,8 +15,8 @@ public class SchemaRegistryClientWrapperTests
         public bool Disposed { get; private set; }
         public List<string> RegisterSubjects { get; } = new();
         public List<string> CompatibilitySubjects { get; } = new();
-        public Func<IList<string>> SubjectsProvider { get; set; } = () => new List<string>();
-        public Func<IList<int>> VersionsProvider { get; set; } = () => new List<int>();
+        public Func<List<string>> SubjectsProvider { get; set; } = () => new List<string>();
+        public Func<List<int>> VersionsProvider { get; set; } = () => new List<int>();
         public Func<int> RegisterReturn { get; set; } = () => 1;
         public Func<bool> CompatibleReturn { get; set; } = () => true;
 


### PR DESCRIPTION
## Summary
- fix FakeClient return types in SchemaRegistryClientWrapperTests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857ffa1e93c8327ad500933c03fcf3b