### PR TITLE
Add Avro management unit tests

### DIFF
--- a/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
+++ b/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Abstractions;
+using KsqlDsl.Serialization.Avro.Management;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaRegistrationServiceTests
+{
+    [Topic("topic")]
+    private class Sample
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+
+    private static (AvroSchemaRegistrationService svc, FakeSchemaRegistryClient fake) CreateService()
+    {
+        var proxy = DispatchProxy.Create<ISchemaRegistryClient, FakeSchemaRegistryClient>();
+        var fake = (FakeSchemaRegistryClient)proxy!;
+        var svc = new AvroSchemaRegistrationService(proxy, new NullLoggerFactory());
+        return (svc, fake);
+    }
+
+    [Fact]
+    public void Constructor_NullClient_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AvroSchemaRegistrationService(null!, null));
+    }
+
+    [Fact]
+    public async Task RegisterAllSchemasAsync_RegistersAndStores()
+    {
+        var (svc, fake) = CreateService();
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var map = new Dictionary<Type, AvroEntityConfiguration> { { typeof(Sample), cfg } };
+        await svc.RegisterAllSchemasAsync(map);
+        Assert.Contains("topic-key", fake.RegisterSubjects);
+        Assert.Contains("topic-value", fake.RegisterSubjects);
+        var info = await svc.GetSchemaInfoAsync<Sample>();
+        Assert.Equal(typeof(Sample), info.EntityType);
+    }
+
+    [Fact]
+    public async Task GetAllRegisteredSchemasAsync_ReturnsList()
+    {
+        var (svc, _) = CreateService();
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        await svc.RegisterAllSchemasAsync(new Dictionary<Type, AvroEntityConfiguration> { { typeof(Sample), cfg } });
+        var all = await svc.GetAllRegisteredSchemasAsync();
+        Assert.Single(all);
+    }
+}

--- a/tests/Serialization/AvroSchemaRepositoryTests.cs
+++ b/tests/Serialization/AvroSchemaRepositoryTests.cs
@@ -1,0 +1,37 @@
+using KsqlDsl.Serialization.Avro.Core;
+using KsqlDsl.Serialization.Avro.Management;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaRepositoryTests
+{
+    private class Sample
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void StoreAndRetrieve_Works()
+    {
+        var repo = new AvroSchemaRepository();
+        var info = new AvroSchemaInfo
+        {
+            EntityType = typeof(Sample),
+            TopicName = "t",
+            KeySchemaId = 1,
+            ValueSchemaId = 2
+        };
+
+        repo.StoreSchemaInfo(info);
+
+        Assert.True(repo.IsRegistered(typeof(Sample)));
+        Assert.Same(info, repo.GetSchemaInfo(typeof(Sample)));
+        Assert.Same(info, repo.GetSchemaInfoByTopic("t"));
+        Assert.Contains(info, repo.GetAllSchemas());
+
+        repo.Clear();
+        Assert.False(repo.IsRegistered(typeof(Sample)));
+        Assert.Empty(repo.GetAllSchemas());
+    }
+}

--- a/tests/Serialization/AvroSchemaVersionManagerTests.cs
+++ b/tests/Serialization/AvroSchemaVersionManagerTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Avro.Management;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSchemaVersionManagerTests
+{
+    [Topic("topic")]
+    private class Sample
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+
+    private static (AvroSchemaVersionManager mgr, FakeSchemaRegistryClient fake) CreateManager()
+    {
+        var proxy = DispatchProxy.Create<ISchemaRegistryClient, FakeSchemaRegistryClient>();
+        var fake = (FakeSchemaRegistryClient)proxy!;
+        var mgr = new AvroSchemaVersionManager(proxy, new NullLoggerFactory());
+        return (mgr, fake);
+    }
+
+    [Fact]
+    public async Task CanUpgradeAsync_ReturnsClientValue()
+    {
+        var (mgr, fake) = CreateManager();
+        fake.CompatibilityResult = false;
+        var result = await mgr.CanUpgradeAsync<Sample>("schema");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_Incompatible_ReturnsFailure()
+    {
+        var (mgr, fake) = CreateManager();
+        fake.CompatibilityResult = false;
+        var result = await mgr.UpgradeAsync<Sample>();
+        Assert.False(result.Success);
+        Assert.Contains("compatible", result.Reason);
+    }
+
+    [Fact]
+    public async Task UpgradeAsync_Success_ReturnsNewId()
+    {
+        var (mgr, fake) = CreateManager();
+        fake.RegisterReturn = 5;
+        var result = await mgr.UpgradeAsync<Sample>();
+        Assert.True(result.Success);
+        Assert.Equal(5, result.NewSchemaId);
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_ReturnsVersion()
+    {
+        var (mgr, fake) = CreateManager();
+        fake.LatestVersion = 3;
+        var version = await mgr.GetLatestVersionAsync<Sample>();
+        Assert.Equal(3, version);
+    }
+
+    [Fact]
+    public async Task GetVersionHistoryAsync_ReturnsValues()
+    {
+        var (mgr, fake) = CreateManager();
+        fake.VersionsResult = new int[] { 1, 2 };
+        var list = await mgr.GetVersionHistoryAsync<Sample>();
+        Assert.Equal(2, list.Count);
+    }
+
+    [Fact]
+    public void GetTopicName_UsesAttribute()
+    {
+        var (mgr, _) = CreateManager();
+        var name = (string)typeof(AvroSchemaVersionManager)
+            .GetMethod("GetTopicName", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(mgr, new object[] { typeof(Sample) })!;
+        Assert.Equal("topic", name);
+    }
+}

--- a/tests/Serialization/FakeSchemaRegistryClient.cs
+++ b/tests/Serialization/FakeSchemaRegistryClient.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
+
+namespace KsqlDsl.Tests.Serialization;
+
+internal class FakeSchemaRegistryClient : DispatchProxy
+{
+    public List<string> RegisterSubjects { get; } = new();
+    public int RegisterReturn { get; set; } = 1;
+    public bool CompatibilityResult { get; set; } = true;
+    public IList<int> VersionsResult { get; set; } = new List<int>();
+    public int LatestVersion { get; set; } = 1;
+    public string SchemaString { get; set; } = "schema";
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        switch (targetMethod?.Name)
+        {
+            case nameof(ISchemaRegistryClient.RegisterSchemaAsync):
+                RegisterSubjects.Add((string)args![0]!);
+                return Task.FromResult(RegisterReturn);
+            case nameof(ISchemaRegistryClient.IsCompatibleAsync):
+                return Task.FromResult(CompatibilityResult);
+            case nameof(ISchemaRegistryClient.GetSubjectVersionsAsync):
+                return Task.FromResult(VersionsResult);
+            case nameof(ISchemaRegistryClient.GetRegisteredSchemaAsync):
+                var subject = (string)args![0]!;
+                var version = (int)args[1]!;
+                var regType = typeof(Schema).Assembly.GetType("Confluent.SchemaRegistry.RegisteredSchema")!;
+                var obj = Activator.CreateInstance(regType, subject, version, RegisterReturn, SchemaString, SchemaType.Avro, null)!;
+                return Task.FromResult(obj);
+            case nameof(IDisposable.Dispose):
+                return null;
+        }
+        throw new NotImplementedException(targetMethod?.Name);
+    }
+}

--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -56,5 +56,52 @@ public class ResilientAvroSerializerManagerTests
         var delay2 = InvokePrivate<TimeSpan>(mgr, "CalculateDelay", new[] { typeof(AvroRetryPolicy), typeof(int) }, null, policy, 3);
         Assert.Equal(TimeSpan.FromMilliseconds(100), delay1);
         Assert.Equal(TimeSpan.FromMilliseconds(400), delay2);
+}
+
+    private static ResilientAvroSerializerManager CreateManager(FakeSchemaRegistryClient fake)
+    {
+        var options = new AvroOperationRetrySettings
+        {
+            SchemaRegistration = new AvroRetryPolicy { MaxAttempts = 1 },
+            SchemaRetrieval = new AvroRetryPolicy { MaxAttempts = 1 },
+            CompatibilityCheck = new AvroRetryPolicy { MaxAttempts = 1 }
+        };
+        var proxy = DispatchProxy.Create<ISchemaRegistryClient, FakeSchemaRegistryClient>();
+        var proxyFake = (FakeSchemaRegistryClient)proxy!;
+        // copy settings from provided fake
+        proxyFake.RegisterReturn = fake.RegisterReturn;
+        proxyFake.CompatibilityResult = fake.CompatibilityResult;
+        proxyFake.VersionsResult = fake.VersionsResult;
+        proxyFake.SchemaString = fake.SchemaString;
+        var mgr = new ResilientAvroSerializerManager(proxy, Microsoft.Extensions.Options.Options.Create(options), NullLogger<ResilientAvroSerializerManager>.Instance);
+        return mgr;
+    }
+
+    [Fact]
+    public async Task RegisterSchemaWithRetryAsync_ReturnsId()
+    {
+        var fake = new FakeSchemaRegistryClient { RegisterReturn = 42 };
+        var mgr = CreateManager(fake);
+        var id = await mgr.RegisterSchemaWithRetryAsync("s", "sc");
+        Assert.Equal(42, id);
+    }
+
+    [Fact]
+    public async Task GetSchemaWithRetryAsync_ReturnsInfo()
+    {
+        var fake = new FakeSchemaRegistryClient { RegisterReturn = 5, SchemaString = "abc" };
+        var mgr = CreateManager(fake);
+        var info = await mgr.GetSchemaWithRetryAsync("topic-value", 1);
+        Assert.Equal(5, info.ValueSchemaId);
+        Assert.Equal("abc", info.ValueSchema);
+    }
+
+    [Fact]
+    public async Task CheckCompatibilityWithRetryAsync_ReturnsValue()
+    {
+        var fake = new FakeSchemaRegistryClient { CompatibilityResult = false };
+        var mgr = CreateManager(fake);
+        var result = await mgr.CheckCompatibilityWithRetryAsync("s", "sc");
+        Assert.False(result);
     }
 }

--- a/tests/Serialization/SchemaUpgradeResultTests.cs
+++ b/tests/Serialization/SchemaUpgradeResultTests.cs
@@ -1,0 +1,25 @@
+using System;
+using KsqlDsl.Serialization.Avro.Management;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class SchemaUpgradeResultTests
+{
+    [Fact]
+    public void Properties_Work()
+    {
+        var now = DateTime.UtcNow;
+        var result = new SchemaUpgradeResult
+        {
+            Success = true,
+            NewSchemaId = 3,
+            Reason = "ok",
+            UpgradedAt = now
+        };
+        Assert.True(result.Success);
+        Assert.Equal(3, result.NewSchemaId);
+        Assert.Equal("ok", result.Reason);
+        Assert.Equal(now, result.UpgradedAt);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable `FakeSchemaRegistryClient` for tests
- test repository operations
- test registration service behaviour
- test schema version manager logic
- test schema upgrade result properties
- extend serializer manager tests to cover retry APIs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858013cfca083279528aa1886f61733