### PR TITLE
Fix missing Task using directive

### DIFF
--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using static KsqlDsl.Tests.PrivateAccessor;
 using Microsoft.Extensions.Logging.Abstractions;
 using KsqlDsl.Configuration.Options;


### PR DESCRIPTION
## Summary
- fix `Task` type resolution in ResilientAvroSerializerManagerTests

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858040eac7483279dbc43c701406d23