### PR TITLE
Fix serialization test build errors

### DIFF
--- a/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
+++ b/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Confluent.SchemaRegistry;
 using KsqlDsl.Core.Abstractions;
-using KsqlDsl.Serialization.Abstractions;
 using KsqlDsl.Serialization.Avro.Management;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;

--- a/tests/Serialization/AvroSchemaVersionManagerTests.cs
+++ b/tests/Serialization/AvroSchemaVersionManagerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Confluent.SchemaRegistry;
 using KsqlDsl.Core.Abstractions;

--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
 using static KsqlDsl.Tests.PrivateAccessor;
 using Microsoft.Extensions.Logging.Abstractions;
 using KsqlDsl.Configuration.Options;


### PR DESCRIPTION
## Summary
- include missing using directives for DispatchProxy
- ensure Confluent SchemaRegistry client is referenced correctly in tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685807cd6a6083278824483d2a8d99f1