### PR TITLE
Fix tests compile error

### DIFF
--- a/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
+++ b/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Confluent.SchemaRegistry;
 using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Abstractions;
 using KsqlDsl.Serialization.Avro.Management;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;


### PR DESCRIPTION
## Summary
- add missing namespace in AvroSchemaRegistrationServiceTests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685809799e608327862b4be983b4927d