### PR TITLE
Fix ambiguous schema registry client in tests

### DIFF
--- a/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
+++ b/tests/Serialization/AvroSchemaRegistrationServiceTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
+using ConfluentClient = Confluent.SchemaRegistry.ISchemaRegistryClient;
+using KsqlAbstractionClient = KsqlDsl.Serialization.Abstractions.ISchemaRegistryClient;
 using Confluent.SchemaRegistry;
 using KsqlDsl.Core.Abstractions;
 using KsqlDsl.Serialization.Abstractions;
@@ -22,7 +24,7 @@ public class AvroSchemaRegistrationServiceTests
 
     private static (AvroSchemaRegistrationService svc, FakeSchemaRegistryClient fake) CreateService()
     {
-        var proxy = DispatchProxy.Create<ISchemaRegistryClient, FakeSchemaRegistryClient>();
+        var proxy = DispatchProxy.Create<ConfluentClient, FakeSchemaRegistryClient>();
         var fake = (FakeSchemaRegistryClient)proxy!;
         var svc = new AvroSchemaRegistrationService(proxy, new NullLoggerFactory());
         return (svc, fake);


### PR DESCRIPTION
## Summary
- alias the Confluent and internal `ISchemaRegistryClient` types in `AvroSchemaRegistrationServiceTests`
- use the aliased type when creating the dispatch proxy

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580bab5d6483278d998ddc0dd92015