### PR TITLE
Fix schema registry proxy return types

### DIFF
--- a/tests/Serialization/FakeSchemaRegistryClient.cs
+++ b/tests/Serialization/FakeSchemaRegistryClient.cs
@@ -30,8 +30,13 @@ internal class FakeSchemaRegistryClient : DispatchProxy
                 var subject = (string)args![0]!;
                 var version = (int)args[1]!;
                 var regType = typeof(Schema).Assembly.GetType("Confluent.SchemaRegistry.RegisteredSchema")!;
-                var obj = Activator.CreateInstance(regType, subject, version, RegisterReturn, SchemaString, SchemaType.Avro, null)!;
-                return Task.FromResult(obj);
+                var schemaVersion = version == -1 ? LatestVersion : version;
+                var obj = Activator.CreateInstance(regType, subject, schemaVersion, RegisterReturn, SchemaString, SchemaType.Avro, null)!;
+                var fromResult = typeof(Task)
+                    .GetMethod("FromResult")!
+                    .MakeGenericMethod(regType)
+                    .Invoke(null, new[] { obj });
+                return fromResult!;
             case nameof(IDisposable.Dispose):
                 return null;
         }


### PR DESCRIPTION
## Summary
- ensure FakeSchemaRegistryClient returns proper Task types and latest version

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68580e856b508327ae2f07f478d4e126