### PR TITLE
Fix version history stub

### DIFF
--- a/tests/Serialization/AvroSchemaVersionManagerTests.cs
+++ b/tests/Serialization/AvroSchemaVersionManagerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Confluent.SchemaRegistry;
 using KsqlDsl.Core.Abstractions;
@@ -68,7 +69,7 @@ public class AvroSchemaVersionManagerTests
     public async Task GetVersionHistoryAsync_ReturnsValues()
     {
         var (mgr, fake) = CreateManager();
-        fake.VersionsResult = new int[] { 1, 2 };
+        fake.VersionsResult = new List<int> { 1, 2 };
         var list = await mgr.GetVersionHistoryAsync<Sample>();
         Assert.Equal(2, list.Count);
     }

--- a/tests/Serialization/FakeSchemaRegistryClient.cs
+++ b/tests/Serialization/FakeSchemaRegistryClient.cs
@@ -11,7 +11,7 @@ internal class FakeSchemaRegistryClient : DispatchProxy
     public List<string> RegisterSubjects { get; } = new();
     public int RegisterReturn { get; set; } = 1;
     public bool CompatibilityResult { get; set; } = true;
-    public IList<int> VersionsResult { get; set; } = new List<int>();
+    public List<int> VersionsResult { get; set; } = new();
     public int LatestVersion { get; set; } = 1;
     public string SchemaString { get; set; } = "schema";
 


### PR DESCRIPTION
## Summary
- fix FakeSchemaRegistryClient so it returns `List<int>` for schema versions
- update test to set `List<int>` and add using for `System.Collections.Generic`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580fdf888c8327b33eec888b25c4ad