### PR TITLE
Fix invalid cast by implementing IModelBuilder

### DIFF
--- a/src/Core/Modeling/ModelBuilder.cs
+++ b/src/Core/Modeling/ModelBuilder.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 namespace KsqlDsl.Core.Modeling;
-internal class ModelBuilder
+internal class ModelBuilder : IModelBuilder
 {
     private readonly Dictionary<Type, EntityModel> _entityModels = new();
     private readonly ValidationMode _validationMode;


### PR DESCRIPTION
## Summary
- implement the `IModelBuilder` interface in `ModelBuilder`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581669ccb483279eeadc621d282767