### PR TITLE
Add tests for Avro builder and serialization manager

### DIFF
--- a/tests/Serialization/AvroEntityConfigurationBuilderTests.cs
+++ b/tests/Serialization/AvroEntityConfigurationBuilderTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroEntityConfigurationBuilderTests
+{
+    [Topic("sample")]
+    private class Sample
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void Constructor_NullConfiguration_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AvroEntityConfigurationBuilder<Sample>(null!));
+    }
+
+    private AvroEntityConfigurationBuilder<Sample> CreateBuilder()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        return new AvroEntityConfigurationBuilder<Sample>(cfg);
+    }
+
+    [Fact]
+    public void ToTopic_SetsName()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        var returned = builder.ToTopic("t1");
+        Assert.Same(builder, returned);
+        Assert.Equal("t1", cfg.TopicName);
+    }
+
+    [Fact]
+    public void HasKey_SetsKeyProperties()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        builder.HasKey(s => s.Id);
+        Assert.Single(cfg.KeyProperties!);
+        Assert.Equal(nameof(Sample.Id), cfg.KeyProperties![0].Name);
+    }
+
+    [Fact]
+    public void WithPartitions_SetsValue()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        builder.WithPartitions(3);
+        Assert.Equal(3, cfg.Partitions);
+    }
+
+    [Fact]
+    public void WithReplicationFactor_SetsValue()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        builder.WithReplicationFactor(2);
+        Assert.Equal(2, cfg.ReplicationFactor);
+    }
+
+    [Fact]
+    public void ValidateOnStartup_SetsFlag()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        builder.ValidateOnStartup(false);
+        Assert.False(cfg.ValidateOnStartup);
+    }
+
+    [Fact]
+    public void EnableCaching_SetsFlag()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        builder.EnableCaching(false);
+        Assert.False(cfg.EnableCaching);
+    }
+
+    [Fact]
+    public void AsStream_SetsCustomSetting()
+    {
+        var builder = CreateBuilder();
+        builder.AsStream();
+        var cfg = builder.Build();
+        Assert.True(cfg.CustomSettings.TryGetValue("StreamTableType", out var v));
+        Assert.Equal("Stream", v);
+    }
+
+    [Fact]
+    public void AsTable_SetsCustomSetting()
+    {
+        var builder = CreateBuilder();
+        builder.AsTable();
+        var cfg = builder.Build();
+        Assert.True(cfg.CustomSettings.TryGetValue("StreamTableType", out var v));
+        Assert.Equal("Table", v);
+    }
+
+    [Fact]
+    public void Build_ReturnsConfiguration()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        Assert.Same(cfg, builder.Build());
+    }
+
+    [Fact]
+    public void ExtractProperties_SupportsComposite()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = new AvroEntityConfigurationBuilder<Sample>(cfg);
+        var method = typeof(AvroEntityConfigurationBuilder<Sample>).GetMethod("ExtractProperties", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var props = (PropertyInfo[])method.Invoke(builder, new object[] { (System.Linq.Expressions.Expression<Func<Sample, object>>) (s => new { s.Id, s.Name }) })!;
+        Assert.Equal(2, props.Length);
+        Assert.Contains(props, p => p.Name == nameof(Sample.Id));
+        Assert.Contains(props, p => p.Name == nameof(Sample.Name));
+    }
+}

--- a/tests/Serialization/AvroEntityConfigurationExtensionsTests.cs
+++ b/tests/Serialization/AvroEntityConfigurationExtensionsTests.cs
@@ -1,0 +1,41 @@
+using System;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroEntityConfigurationExtensionsTests
+{
+    [Topic("topic")]
+    private class Sample
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void Configure_WrongType_Throws()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        Assert.Throws<ArgumentException>(() => cfg.Configure<string>());
+    }
+
+    [Fact]
+    public void Configure_ReturnsBuilder()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        var builder = cfg.Configure<Sample>();
+        Assert.NotNull(builder);
+    }
+
+    [Fact]
+    public void IsStreamType_And_IsTableType()
+    {
+        var cfg = new AvroEntityConfiguration(typeof(Sample));
+        cfg.CustomSettings["StreamTableType"] = "Stream";
+        Assert.True(cfg.IsStreamType());
+        cfg.CustomSettings["StreamTableType"] = "Table";
+        Assert.True(cfg.IsTableType());
+    }
+}

--- a/tests/Serialization/AvroSerializationManagerTests.cs
+++ b/tests/Serialization/AvroSerializationManagerTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading.Tasks;
+using System.Reflection;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Serialization.Abstractions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Serialization;
+
+public class AvroSerializationManagerTests
+{
+    [Topic("topic")]
+    private class Sample
+    {
+        [Key]
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private static AvroSerializationManager<Sample> CreateManager(FakeSchemaRegistryClient fake)
+    {
+        var proxy = DispatchProxy.Create<Confluent.SchemaRegistry.ISchemaRegistryClient, FakeSchemaRegistryClient>();
+        var proxyFake = (FakeSchemaRegistryClient)proxy!;
+        proxyFake.RegisterReturn = fake.RegisterReturn;
+        proxyFake.CompatibilityResult = fake.CompatibilityResult;
+        proxyFake.LatestVersion = fake.LatestVersion;
+        proxyFake.SchemaString = fake.SchemaString;
+        var mgr = new AvroSerializationManager<Sample>(proxy, new NullLoggerFactory());
+        return mgr;
+    }
+
+    [Fact]
+    public async Task GetSerializers_And_Deserializers_Work()
+    {
+        var mgr = CreateManager(new FakeSchemaRegistryClient());
+        var ser1 = await mgr.GetSerializersAsync();
+        var ser2 = await mgr.GetSerializersAsync();
+        Assert.Same(ser1, ser2); // cached
+        var des1 = await mgr.GetDeserializersAsync();
+        var des2 = await mgr.GetDeserializersAsync();
+        Assert.Same(des1, des2);
+        Assert.Equal(typeof(Sample), mgr.EntityType);
+    }
+
+    [Fact]
+    public async Task ValidateRoundTripAsync_ReturnsTrue()
+    {
+        var mgr = CreateManager(new FakeSchemaRegistryClient());
+        var result = await mgr.ValidateRoundTripAsync(new Sample { Id = 1, Name = "a" });
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task CanUpgradeSchemaAsync_ReturnsValue()
+    {
+        var fake = new FakeSchemaRegistryClient { CompatibilityResult = false };
+        var mgr = CreateManager(fake);
+        var result = await mgr.CanUpgradeSchemaAsync();
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task UpgradeSchemaAsync_Success_ClearsCache()
+    {
+        var fake = new FakeSchemaRegistryClient { RegisterReturn = 10 };
+        var mgr = CreateManager(fake);
+        var first = await mgr.GetSerializersAsync();
+        var res = await mgr.UpgradeSchemaAsync();
+        Assert.True(res.Success);
+        var second = await mgr.GetSerializersAsync();
+        Assert.NotSame(first, second); // cache cleared
+    }
+
+    [Fact]
+    public async Task GetCurrentSchemasAsync_ReturnsSchemas()
+    {
+        var mgr = CreateManager(new FakeSchemaRegistryClient());
+        var schemas = await mgr.GetCurrentSchemasAsync();
+        Assert.Contains("record", schemas.valueSchema);
+    }
+
+    [Fact]
+    public async Task ClearCache_RemovesManager()
+    {
+        var mgr = CreateManager(new FakeSchemaRegistryClient());
+        var first = await mgr.GetSerializersAsync();
+        mgr.ClearCache();
+        var second = await mgr.GetSerializersAsync();
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public async Task Dispose_ClearsCache()
+    {
+        var mgr = CreateManager(new FakeSchemaRegistryClient());
+        var first = await mgr.GetSerializersAsync();
+        mgr.Dispose();
+        var second = await mgr.GetSerializersAsync();
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public async Task GetStatistics_ReflectsOperations()
+    {
+        var mgr = CreateManager(new FakeSchemaRegistryClient());
+        await mgr.GetSerializersAsync();
+        await mgr.GetDeserializersAsync();
+        var stats = mgr.GetStatistics();
+        Assert.True(stats.TotalSerializations > 0 || stats.TotalDeserializations > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `AvroEntityConfigurationBuilder` covering configuration methods
- add extension tests for `AvroEntityConfigurationExtensions`
- add `AvroSerializationManager` tests verifying caching, schema upgrade, and statistics

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858200c83388327b53a12b790de2d67