### PR TITLE
Fix QueryExecutionPipelineTests compilation errors

### DIFF
--- a/tests/Query/Pipeline/QueryExecutionPipelineTests.cs
+++ b/tests/Query/Pipeline/QueryExecutionPipelineTests.cs
@@ -69,6 +69,7 @@ public class QueryExecutionPipelineTests
         await pipeline.StopAllStreamingQueriesAsync();
 
         Assert.True(executor.StopCalled);
+    }
     [Fact]
     public void GetDiagnostics_ReturnsConstant()
     {
@@ -120,6 +121,5 @@ public class QueryExecutionPipelineTests
         Assert.True(result.Success);
         Assert.NotNull(result.ExecutedAt);
         Assert.NotNull(result.Data);
-    }
     }
 }


### PR DESCRIPTION
## Summary
- fix missing braces in `QueryExecutionPipelineTests` to resolve CS0106 errors

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685823faab14832790000640fe9dc594