### PR TITLE
Add tests for Kafka consumer manager and messaging models

### DIFF
--- a/tests/Messaging/KafkaConsumerManagerTests.cs
+++ b/tests/Messaging/KafkaConsumerManagerTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Confluent.Kafka;
+using Confluent.SchemaRegistry;
+using KsqlDsl.Configuration;
+using KsqlDsl.Messaging.Configuration;
+using KsqlDsl.Messaging.Consumers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using static KsqlDsl.Tests.PrivateAccessor;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class KafkaConsumerManagerTests
+{
+    private class SampleEntity
+    {
+        [KsqlDsl.Core.Abstractions.Key]
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void BuildConsumerConfig_ReturnsConfiguredValues()
+    {
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "server", ClientId = "cid" },
+            Topics = new Dictionary<string, TopicSection>
+            {
+                ["topic"] = new TopicSection
+                {
+                    Consumer = new ConsumerSection
+                    {
+                        GroupId = "gid",
+                        AutoOffsetReset = "Earliest",
+                        EnableAutoCommit = false,
+                        AutoCommitIntervalMs = 100,
+                        SessionTimeoutMs = 200,
+                        HeartbeatIntervalMs = 300,
+                        MaxPollIntervalMs = 400,
+                        FetchMinBytes = 5,
+                        FetchMaxBytes = 10,
+                        IsolationLevel = "ReadCommitted",
+                        AdditionalProperties = new Dictionary<string,string>{{"p","v"}}
+                    }
+                }
+            }
+        };
+        var manager = new KafkaConsumerManager(Options.Create(options), new NullLoggerFactory());
+        var config = InvokePrivate<ConsumerConfig>(manager, "BuildConsumerConfig", new[] { typeof(string), typeof(KafkaSubscriptionOptions) }, null, "topic", null);
+
+        Assert.Equal("server", config.BootstrapServers);
+        Assert.Equal("cid", config.ClientId);
+        Assert.Equal("gid", config.GroupId);
+        Assert.Equal(AutoOffsetReset.Earliest, config.AutoOffsetReset);
+        Assert.False(config.EnableAutoCommit);
+        Assert.Equal(100, config.AutoCommitIntervalMs);
+        Assert.Equal(200, config.SessionTimeoutMs);
+        Assert.Equal(300, config.HeartbeatIntervalMs);
+        Assert.Equal(400, config.MaxPollIntervalMs);
+        Assert.Equal(5, config.FetchMinBytes);
+        Assert.Equal(10, config.FetchMaxBytes);
+        Assert.Equal(IsolationLevel.ReadCommitted, config.IsolationLevel);
+        Assert.Equal("v", config.Get("p"));
+    }
+
+    [Fact]
+    public void GetOrCreateSerializationManager_CachesInstance()
+    {
+        var options = new KsqlDslOptions();
+        var manager = (KafkaConsumerManager)FormatterServices.GetUninitializedObject(typeof(KafkaConsumerManager));
+        typeof(KafkaConsumerManager).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, options);
+        typeof(KafkaConsumerManager).GetField("_loggerFactory", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new NullLoggerFactory());
+        typeof(KafkaConsumerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
+        typeof(KafkaConsumerManager).GetField("_schemaRegistryClient", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager,
+            new Lazy<ISchemaRegistryClient>(() => new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = "localhost" })));
+
+        var first = InvokePrivate<object>(manager, "GetOrCreateSerializationManager", Type.EmptyTypes, new[] { typeof(SampleEntity) });
+        var second = InvokePrivate<object>(manager, "GetOrCreateSerializationManager", Type.EmptyTypes, new[] { typeof(SampleEntity) });
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetEntityModel_ReturnsModelWithAttributes()
+    {
+        var manager = (KafkaConsumerManager)FormatterServices.GetUninitializedObject(typeof(KafkaConsumerManager));
+        typeof(KafkaConsumerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
+        var model = InvokePrivate<KsqlDsl.Core.Abstractions.EntityModel>(manager, "GetEntityModel", Type.EmptyTypes, new[] { typeof(SampleEntity) });
+        Assert.Equal(typeof(SampleEntity), model.EntityType);
+        Assert.Single(model.KeyProperties);
+        Assert.Equal("SampleEntity", model.TopicAttribute?.TopicName ?? model.EntityType.Name);
+    }
+}

--- a/tests/Messaging/MessagingExceptionTests.cs
+++ b/tests/Messaging/MessagingExceptionTests.cs
@@ -1,0 +1,58 @@
+using System;
+using KsqlDsl.Messaging.Consumers.Exceptions;
+using KsqlDsl.Messaging.Producers.Exception;
+using KsqlDsl.Messaging.Producers.Core;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class MessagingExceptionTests
+{
+    [Fact]
+    public void ConsumerPoolException_Constructors()
+    {
+        var ex1 = new ConsumerPoolException("msg");
+        Assert.Equal("msg", ex1.Message);
+        var inner = new Exception("inner");
+        var ex2 = new ConsumerPoolException("m", inner);
+        Assert.Equal(inner, ex2.InnerException);
+    }
+
+    [Fact]
+    public void KafkaConsumerException_Constructors()
+    {
+        var ex1 = new KafkaConsumerException("e1");
+        Assert.Equal("e1", ex1.Message);
+        var inner = new Exception("i");
+        var ex2 = new KafkaConsumerException("e2", inner);
+        Assert.Equal(inner, ex2.InnerException);
+    }
+
+    [Fact]
+    public void KafkaBatchSendException_SetsBatchResult()
+    {
+        var batch = new KafkaBatchDeliveryResult { Topic = "t" };
+        var ex = new KafkaBatchSendException("bad", batch);
+        Assert.Equal(batch, ex.BatchResult);
+    }
+
+    [Fact]
+    public void KafkaProducerManagerException_Constructors()
+    {
+        var ex1 = new KafkaProducerManagerException("m");
+        Assert.Equal("m", ex1.Message);
+        var inner = new Exception("i");
+        var ex2 = new KafkaProducerManagerException("m2", inner);
+        Assert.Equal(inner, ex2.InnerException);
+    }
+
+    [Fact]
+    public void ProducerPoolException_Constructors()
+    {
+        var ex1 = new ProducerPoolException("m");
+        Assert.Equal("m", ex1.Message);
+        var inner = new Exception("i");
+        var ex2 = new ProducerPoolException("m2", inner);
+        Assert.Equal(inner, ex2.InnerException);
+    }
+}

--- a/tests/Messaging/MessagingPropertyTests.cs
+++ b/tests/Messaging/MessagingPropertyTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Confluent.Kafka;
+using KsqlDsl.Messaging.Consumers.Core;
+using KsqlDsl.Messaging.Producers.Core;
+using Xunit;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class MessagingPropertyTests
+{
+    [Fact]
+    public void KafkaBatchDeliveryResult_AllSuccessful_WhenNoErrors()
+    {
+        var result = new KafkaBatchDeliveryResult { FailedCount = 0 };
+        Assert.True(result.AllSuccessful);
+    }
+
+    [Fact]
+    public void KafkaDeliveryResult_Properties_RoundTrip()
+    {
+        var now = DateTime.UtcNow;
+        var dr = new KafkaDeliveryResult
+        {
+            Topic = "t",
+            Partition = 1,
+            Offset = 2,
+            Timestamp = now,
+            Status = PersistenceStatus.Persisted,
+            Error = null,
+            Latency = TimeSpan.FromMilliseconds(5)
+        };
+        Assert.Equal("t", dr.Topic);
+        Assert.Equal(1, dr.Partition);
+        Assert.Equal(2, dr.Offset);
+        Assert.Equal(now, dr.Timestamp);
+        Assert.Equal(PersistenceStatus.Persisted, dr.Status);
+        Assert.Null(dr.Error);
+        Assert.Equal(TimeSpan.FromMilliseconds(5), dr.Latency);
+    }
+
+    [Fact]
+    public void PooledProducer_Defaults_Settable()
+    {
+        var p = new PooledProducer { UsageCount = 1 };
+        Assert.True(p.IsHealthy);
+        Assert.Equal(1, p.UsageCount);
+    }
+
+    [Fact]
+    public void PooledConsumer_Defaults_Settable()
+    {
+        var c = new PooledConsumer { UsageCount = 3 };
+        Assert.True(c.IsHealthy);
+        Assert.Equal(3, c.UsageCount);
+        Assert.Empty(c.AssignedPartitions);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for KafkaConsumerManager internals
- cover simple messaging models and exception classes

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685826368ad88327a1123bd6c3cf4db1