### PR TITLE
Fix namespace reference for KafkaSubscriptionOptions

### DIFF
--- a/tests/Messaging/KafkaConsumerManagerTests.cs
+++ b/tests/Messaging/KafkaConsumerManagerTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using Confluent.Kafka;
 using Confluent.SchemaRegistry;
 using KsqlDsl.Configuration;
+using KsqlDsl.Configuration.Abstractions;
 using KsqlDsl.Messaging.Configuration;
 using KsqlDsl.Messaging.Consumers;
 using Microsoft.Extensions.Logging.Abstractions;


### PR DESCRIPTION
## Summary
- add missing using directive for `KafkaSubscriptionOptions`

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858277d62ec8327b68b4d2284c8a6ea