### PR TITLE
Fix ValueTask compilation error in tests

### DIFF
--- a/tests/EventSetValidateTests.cs
+++ b/tests/EventSetValidateTests.cs
@@ -1,5 +1,6 @@
 using KsqlDsl.Core.Abstractions;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace KsqlDsl.Tests;


### PR DESCRIPTION
## Summary
- add missing `System.Threading.Tasks` namespace for `ValueTask` in `EventSetValidateTests`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582a874468832792d878694ae0cfe3