### PR TITLE
Fix compile errors in tests

### DIFF
--- a/tests/Core/LoggerFactoryExtensionsTests.cs
+++ b/tests/Core/LoggerFactoryExtensionsTests.cs
@@ -27,7 +27,7 @@ public class LoggerFactoryExtensionsTests
     [Fact]
     public void LogMethods_WithAndWithoutFactory()
     {
-        using var factory = LoggerFactory.Create(builder => builder.AddProvider(new NullLoggerProvider()));
+        using var factory = LoggerFactory.Create(builder => builder.AddProvider(NullLoggerProvider.Instance));
         var logger = factory.CreateLogger<LoggerFactoryExtensionsTests>();
         logger.LogDebugWithLegacySupport(factory, false, "d");
         logger.LogInformationWithLegacySupport(factory, false, "i");

--- a/tests/Core/ModelBuilderTests.cs
+++ b/tests/Core/ModelBuilderTests.cs
@@ -1,5 +1,6 @@
 using KsqlDsl.Core.Abstractions;
 using KsqlDsl.Core.Modeling;
+using KsqlDsl.Core.Extensions;
 using System;
 using System.Linq;
 using Xunit;


### PR DESCRIPTION
## Summary
- reference extension methods in `ModelBuilderTests`
- use `NullLoggerProvider.Instance` in logging tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582b82e84c8327936331d33b1489b1