### PR TITLE
Fix unit tests after manager refactor

### DIFF
--- a/tests/Application/KafkaContextAsyncTests.cs
+++ b/tests/Application/KafkaContextAsyncTests.cs
@@ -10,31 +10,28 @@ namespace KsqlDsl.Tests.Application;
 
 public class KafkaContextAsyncTests
 {
-    private class StubManager : IDisposable
-    {
-        public bool Disposed { get; private set; }
-        public void Dispose() => Disposed = true;
-    }
-
     private class TestContext : KafkaContext
     {
         public TestContext() : base() { }
-        public void ReplaceManagers(object producer, object consumer)
-        {
-            typeof(KafkaContext).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, producer);
-            typeof(KafkaContext).GetField("_consumerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, consumer);
-        }
     }
 
     [Fact]
     public async Task DisposeAsyncCore_DisposesManagers()
     {
         var ctx = new TestContext();
-        var p = new StubManager();
-        var c = new StubManager();
-        ctx.ReplaceManagers(p, c);
         await ctx.DisposeAsync();
-        Assert.True(p.Disposed);
-        Assert.True(c.Disposed);
+
+        var producer = typeof(KafkaContext).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(ctx)!;
+        var consumer = typeof(KafkaContext).GetField("_consumerManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(ctx)!;
+
+        var prodDisposed = (bool)producer.GetType().GetField("_disposed", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(producer)!;
+        var consDisposed = (bool)consumer.GetType().GetField("_disposed", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(consumer)!;
+
+        Assert.True(prodDisposed);
+        Assert.True(consDisposed);
     }
 }

--- a/tests/Core/CoreExceptionsTests.cs
+++ b/tests/Core/CoreExceptionsTests.cs
@@ -46,7 +46,7 @@ public class CoreExceptionsTests
     {
         var ex1 = new EntityModelException(typeof(string), "bad");
         Assert.Equal(typeof(string), ex1.EntityType);
-        Assert.Contains("string", ex1.Message);
+        Assert.Contains("String", ex1.Message);
         var inner = new Exception("i");
         var ex2 = new EntityModelException(typeof(int), "x", inner);
         Assert.Equal(inner, ex2.InnerException);

--- a/tests/Messaging/Consumers/ConsumerInstanceTests.cs
+++ b/tests/Messaging/Consumers/ConsumerInstanceTests.cs
@@ -16,7 +16,7 @@ public class ConsumerInstanceTests
             RentedAt = System.DateTime.UtcNow,
             IsActive = true
         };
-        Assert.Equal("string:t:g", inst.ConsumerKey.ToString());
+        Assert.Equal("String:t:g", inst.ConsumerKey.ToString());
         Assert.NotNull(inst.PooledConsumer);
         Assert.True(inst.IsActive);
         Assert.True(inst.RentedAt <= System.DateTime.UtcNow);


### PR DESCRIPTION
## Summary
- update EventSetWithServicesSendTests to work with concrete KafkaProducerManager
- check manager dispose flags via reflection in KafkaContextAsyncTests
- adjust string assertions in CoreExceptionsTests and ConsumerInstanceTests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582c876dc88327ad73a330fc2d94a1