### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/Application/EventSetWithSimplifiedServicesSendTests.cs
+++ b/tests/Application/EventSetWithSimplifiedServicesSendTests.cs
@@ -1,0 +1,75 @@
+using KsqlDsl;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Core.Context;
+using KsqlDsl.Messaging.Abstractions;
+using KsqlDsl.Messaging.Producers.Core;
+using KsqlDsl.Configuration;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace KsqlDsl.Tests.Application;
+
+public class EventSetWithSimplifiedServicesSendTests
+{
+    private class StubProducer<T> : IKafkaProducer<T> where T : class
+    {
+        public bool Sent;
+        public string TopicName => "t";
+        public Task<KafkaDeliveryResult> SendAsync(T message, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+        {
+            Sent = true;
+            return Task.FromResult(new KafkaDeliveryResult());
+        }
+        public Task<KafkaBatchDeliveryResult> SendBatchAsync(IEnumerable<T> messages, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+        {
+            Sent = true;
+            return Task.FromResult(new KafkaBatchDeliveryResult());
+        }
+        public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private class TestContext : KafkaContext
+    {
+        public TestContext() : base() { }
+        public void SetProducer(object manager)
+        {
+            typeof(KafkaContext).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, manager);
+        }
+    }
+
+    private class Sample { public int Id { get; set; } }
+
+    private static EntityModel CreateModel() => new()
+    {
+        EntityType = typeof(Sample),
+        TopicAttribute = new TopicAttribute("t"),
+        AllProperties = typeof(Sample).GetProperties(),
+        KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! }
+    };
+
+    [Fact]
+    public async Task SendEntityAsync_UsesProducerManager()
+    {
+        var ctx = new TestContext();
+        var manager = new KafkaProducerManager(
+            Microsoft.Extensions.Options.Options.Create(new KsqlDslOptions()),
+            null);
+        ctx.SetProducer(manager);
+
+        var stub = new StubProducer<Sample>();
+        var dict = (System.Collections.Concurrent.ConcurrentDictionary<Type, object>)
+            typeof(KafkaProducerManager).GetField("_producers", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(manager)!;
+        dict[typeof(Sample)] = stub;
+
+        var set = new EventSetWithSimplifiedServices<Sample>(ctx, CreateModel());
+        await PrivateAccessor.InvokePrivate<Task>(set, "SendEntityAsync", new[] { typeof(Sample), typeof(CancellationToken) }, args: new object?[] { new Sample(), CancellationToken.None });
+        Assert.True(stub.Sent);
+    }
+}

--- a/tests/Application/KafkaContextExtraTests.cs
+++ b/tests/Application/KafkaContextExtraTests.cs
@@ -1,0 +1,46 @@
+using KsqlDsl.Application;
+using KsqlDsl.Core.Abstractions;
+using KsqlDsl.Core.Context;
+using KsqlDsl.Serialization.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using KsqlDsl.Tests;
+
+namespace KsqlDsl.Tests.Application;
+
+public class KafkaContextExtraTests
+{
+    private class TestContext : KafkaContext
+    {
+        public TestContext() : base() { }
+        public IReadOnlyDictionary<Type, AvroEntityConfiguration> CallConvert(Dictionary<Type, EntityModel> models)
+            => PrivateAccessor.InvokePrivate<IReadOnlyDictionary<Type, AvroEntityConfiguration>>(this,
+                "ConvertToAvroConfigurations",
+                new[] { typeof(Dictionary<Type, EntityModel>) },
+                args: new object?[] { models });
+    }
+
+    private class Sample { [Key] public int Id { get; set; } }
+
+    private static EntityModel CreateModel() => new()
+    {
+        EntityType = typeof(Sample),
+        TopicAttribute = new TopicAttribute("t"),
+        AllProperties = typeof(Sample).GetProperties(),
+        KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! }
+    };
+
+    [Fact]
+    public void ConvertToAvroConfigurations_MapsModels()
+    {
+        var ctx = new TestContext();
+        var dict = new Dictionary<Type, EntityModel> { [typeof(Sample)] = CreateModel() };
+        var result = ctx.CallConvert(dict);
+        Assert.Single(result);
+        var cfg = result[typeof(Sample)];
+        Assert.Equal("t", cfg.TopicName);
+        Assert.Single(cfg.KeyProperties!);
+    }
+}

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -25,4 +25,24 @@ public class KsqlContextBuilderTests
         var ctx = KsqlContextBuilder.Create().UseSchemaRegistry("u").BuildContext<DummyContext>();
         Assert.IsType<DummyContext>(ctx);
     }
+
+    [Fact]
+    public void Builder_Methods_ConfigureOptions()
+    {
+        var factory = Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance;
+        var builder = KsqlContextBuilder.Create()
+            .UseSchemaRegistry("http://localhost:8081")
+            .EnableLogging(factory)
+            .ConfigureValidation(autoRegister: false, failOnErrors: false, enablePreWarming: false)
+            .WithTimeouts(System.TimeSpan.FromSeconds(5))
+            .EnableDebugMode(true);
+        var options = builder.Build();
+        Assert.NotNull(options.SchemaRegistryClient);
+        Assert.Equal(factory, options.LoggerFactory);
+        Assert.False(options.AutoRegisterSchemas);
+        Assert.False(options.FailOnInitializationErrors);
+        Assert.False(options.EnableCachePreWarming);
+        Assert.Equal(System.TimeSpan.FromSeconds(5), options.SchemaRegistrationTimeout);
+        Assert.True(options.EnableDebugLogging);
+    }
 }

--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -1,0 +1,30 @@
+using Confluent.SchemaRegistry;
+using KsqlDsl.Configuration;
+using KsqlDsl.Messaging.Producers;
+using Microsoft.Extensions.Options;
+using Xunit;
+using static KsqlDsl.Tests.PrivateAccessor;
+
+namespace KsqlDsl.Tests.Messaging;
+
+public class KafkaProducerManagerExtraTests
+{
+    [Fact]
+    public void CreateSchemaRegistryClient_UsesOptions()
+    {
+        var options = new KsqlDslOptions
+        {
+            SchemaRegistry = new SchemaRegistrySection
+            {
+                Url = "u",
+                MaxCachedSchemas = 5,
+                RequestTimeoutMs = 10,
+                AdditionalProperties = new System.Collections.Generic.Dictionary<string,string>{{"p","v"}},
+                SslKeyPassword = "pw"
+            }
+        };
+        var manager = new KafkaProducerManager(Options.Create(options), null);
+        var client = InvokePrivate<object>(manager, "CreateSchemaRegistryClient", System.Type.EmptyTypes);
+        Assert.Equal("CachedSchemaRegistryClient", client!.GetType().Name);
+    }
+}


### PR DESCRIPTION
## Summary
- test EventSetWithSimplifiedServices sending
- cover KafkaContext private conversion helper
- ensure KsqlContextBuilder configuration methods work
- basic check for KafkaProducerManager schema registry client

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582e0857cc8327b16c3cdfa3cd6df9