### PR TITLE
Fix test namespaces

### DIFF
--- a/tests/Application/EventSetWithSimplifiedServicesSendTests.cs
+++ b/tests/Application/EventSetWithSimplifiedServicesSendTests.cs
@@ -4,6 +4,7 @@ using KsqlDsl.Core.Context;
 using KsqlDsl.Messaging.Abstractions;
 using KsqlDsl.Messaging.Producers.Core;
 using KsqlDsl.Configuration;
+using KsqlDsl.Application;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System;

--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -1,5 +1,6 @@
 using Confluent.SchemaRegistry;
 using KsqlDsl.Configuration;
+using KsqlDsl.Messaging.Configuration;
 using KsqlDsl.Messaging.Producers;
 using Microsoft.Extensions.Options;
 using Xunit;


### PR DESCRIPTION
## Summary
- update namespace usage in EventSetWithSimplifiedServicesSendTests
- update namespace usage in KafkaProducerManagerExtraTests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68582fb85cb4832785c3cdfa2e5e4441