### PR TITLE
Fix simplified services test context

### DIFF
--- a/tests/Application/EventSetWithSimplifiedServicesSendTests.cs
+++ b/tests/Application/EventSetWithSimplifiedServicesSendTests.cs
@@ -1,4 +1,5 @@
 using KsqlDsl;
+using KafkaApplication = KsqlDsl.Application.KafkaContext;
 using KsqlDsl.Core.Abstractions;
 using KsqlDsl.Core.Context;
 using KsqlDsl.Messaging.Abstractions;
@@ -35,12 +36,12 @@ public class EventSetWithSimplifiedServicesSendTests
         public void Dispose() { }
     }
 
-    private class TestContext : KafkaContext
+    private class TestContext : KafkaApplication
     {
         public TestContext() : base() { }
         public void SetProducer(object manager)
         {
-            typeof(KafkaContext).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, manager);
+            typeof(KafkaApplication).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, manager);
         }
     }
 


### PR DESCRIPTION
## Summary
- fix `EventSetWithSimplifiedServicesSendTests` to use the application `KafkaContext`

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858309029608327aa08d6ee53e745d9