### PR TITLE
Fix ConvertToAvroConfigurations reflection

### DIFF
--- a/src/Application/KsqlContext.cs
+++ b/src/Application/KsqlContext.cs
@@ -64,7 +64,16 @@ public abstract class KafkaContext : KafkaContextCore
     internal KafkaConsumerManager GetConsumerManager() => _consumerManager;
 
 
-    private IReadOnlyDictionary<Type, AvroEntityConfiguration> ConvertToAvroConfigurations(
+    /// <summary>
+    /// EntityModel の情報を AvroEntityConfiguration へ変換する。
+    /// </summary>
+    /// <param name="entityModels">変換対象のモデル一覧</param>
+    /// <returns>変換後の AvroEntityConfiguration マップ</returns>
+    /// <remarks>
+    /// テストからリフレクションで呼び出されるためアクセスレベルを
+    /// <c>protected</c> に変更する。
+    /// </remarks>
+    protected IReadOnlyDictionary<Type, AvroEntityConfiguration> ConvertToAvroConfigurations(
     Dictionary<Type, EntityModel> entityModels)
     {
         var avroConfigs = new Dictionary<Type, AvroEntityConfiguration>();


### PR DESCRIPTION
## Summary
- expose `ConvertToAvroConfigurations` for tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858334e8dc48327a838064945c3b4a2