### PR TITLE
Fix reflection argument type

### DIFF
--- a/tests/Application/KafkaContextExtraTests.cs
+++ b/tests/Application/KafkaContextExtraTests.cs
@@ -18,7 +18,7 @@ public class KafkaContextExtraTests
         public IReadOnlyDictionary<Type, AvroEntityConfiguration> CallConvert(Dictionary<Type, EntityModel> models)
             => PrivateAccessor.InvokePrivate<IReadOnlyDictionary<Type, AvroEntityConfiguration>>(this,
                 "ConvertToAvroConfigurations",
-                new[] { typeof(Dictionary<Type, EntityModel>) },
+                new[] { models.GetType() },
                 args: new object?[] { models });
     }
 


### PR DESCRIPTION
## Summary
- update KafkaContextExtraTests to reflect runtime dictionary type when invoking ConvertToAvroConfigurations

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685834f599688327bc6d64d70c41fd34