### PR TITLE
Add additional configuration and core tests

### DIFF
--- a/tests/Application/KsqlContextOptionsExtensionsTests.cs
+++ b/tests/Application/KsqlContextOptionsExtensionsTests.cs
@@ -15,6 +15,15 @@ public class KsqlContextOptionsExtensionsTests
     }
 
     [Fact]
+    public void UseSchemaRegistry_WithConfig_ConfiguresClient()
+    {
+        var options = new KsqlContextOptions();
+        var config = new Confluent.SchemaRegistry.SchemaRegistryConfig { Url = "u" };
+        options.UseSchemaRegistry(config);
+        Assert.NotNull(options.SchemaRegistryClient);
+    }
+
+    [Fact]
     public void EnableLogging_SetsLoggerFactory()
     {
         var options = new KsqlContextOptions();

--- a/tests/Application/KsqlContextOptionsTests.cs
+++ b/tests/Application/KsqlContextOptionsTests.cs
@@ -21,4 +21,11 @@ public class KsqlContextOptionsTests
         var options = new KsqlContextOptions { SchemaRegistryClient = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = "url" }), SchemaRegistrationTimeout = System.TimeSpan.Zero };
         Assert.Throws<InvalidOperationException>(() => options.Validate());
     }
+
+    [Fact]
+    public void Validate_WithValidOptions_DoesNotThrow()
+    {
+        var options = new KsqlContextOptions { SchemaRegistryClient = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = "url" }) };
+        options.Validate();
+    }
 }

--- a/tests/Configuration/AvroRetryPolicyTests.cs
+++ b/tests/Configuration/AvroRetryPolicyTests.cs
@@ -19,4 +19,21 @@ public class AvroRetryPolicyTests
         var policy = new AvroRetryPolicy { InitialDelay = System.TimeSpan.Zero };
         Assert.Throws<ArgumentException>(() => policy.Validate());
     }
+
+    [Theory]
+    [InlineData(0, 100, 100, 1)]
+    [InlineData(1, 0, 100, 1)]
+    [InlineData(1, 100, 0, 1)]
+    [InlineData(1, 100, 100, 0)]
+    public void Validate_InvalidValues_Throws(int attempts, int initMs, int maxMs, double backoff)
+    {
+        var policy = new AvroRetryPolicy
+        {
+            MaxAttempts = attempts,
+            InitialDelay = TimeSpan.FromMilliseconds(initMs),
+            MaxDelay = TimeSpan.FromMilliseconds(maxMs),
+            BackoffMultiplier = backoff
+        };
+        Assert.Throws<ArgumentException>(() => policy.Validate());
+    }
 }

--- a/tests/Configuration/KsqlDslOptionsTests.cs
+++ b/tests/Configuration/KsqlDslOptionsTests.cs
@@ -1,0 +1,17 @@
+using KsqlDsl.Configuration;
+using Xunit;
+
+namespace KsqlDsl.Tests.Configuration;
+
+public class KsqlDslOptionsTests
+{
+    [Fact]
+    public void Defaults_AreExpected()
+    {
+        var opt = new KsqlDslOptions();
+        Assert.Equal(ValidationMode.Strict, opt.ValidationMode);
+        Assert.NotNull(opt.Common);
+        Assert.NotNull(opt.Topics);
+        Assert.NotNull(opt.SchemaRegistry);
+    }
+}

--- a/tests/Configuration/SchemaGenerationOptionsTests.cs
+++ b/tests/Configuration/SchemaGenerationOptionsTests.cs
@@ -1,0 +1,31 @@
+using KsqlDsl.Configuration.Abstractions;
+using Xunit;
+
+namespace KsqlDsl.Tests.Configuration;
+
+public class SchemaGenerationOptionsTests
+{
+    [Fact]
+    public void Clone_CopiesAllProperties()
+    {
+        var opt = new SchemaGenerationOptions
+        {
+            CustomName = "c",
+            Namespace = "n",
+            Documentation = "d",
+            PrettyFormat = false,
+            UseKebabCase = true,
+            IncludeDefaultValues = false,
+            ValidateOnGeneration = false
+        };
+        var clone = opt.Clone();
+        Assert.NotSame(opt, clone);
+        Assert.Equal("c", clone.CustomName);
+        Assert.Equal("n", clone.Namespace);
+        Assert.Equal("d", clone.Documentation);
+        Assert.False(clone.PrettyFormat);
+        Assert.True(clone.UseKebabCase);
+        Assert.False(clone.IncludeDefaultValues);
+        Assert.False(clone.ValidateOnGeneration);
+    }
+}

--- a/tests/Core/CoreSettingsProviderTests.cs
+++ b/tests/Core/CoreSettingsProviderTests.cs
@@ -1,0 +1,44 @@
+using KsqlDsl.Core.Configuration;
+using KsqlDsl.Configuration;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.Core;
+
+public class CoreSettingsProviderTests
+{
+    [Fact]
+    public void GetSettings_ReturnsClone()
+    {
+        var provider = new CoreSettingsProvider();
+        var settings = provider.GetSettings();
+        Assert.NotSame(settings, provider.GetSettings());
+        Assert.Equal(ValidationMode.Strict, settings.ValidationMode);
+    }
+
+    [Fact]
+    public void UpdateSettings_Null_Throws()
+    {
+        var provider = new CoreSettingsProvider();
+        Assert.Throws<ArgumentNullException>(() => provider.UpdateSettings(null!));
+    }
+
+    [Fact]
+    public void UpdateSettings_RaisesEventAndClones()
+    {
+        var provider = new CoreSettingsProvider();
+        var raised = false;
+        provider.SettingsChanged += (s, e) =>
+        {
+            raised = true;
+            Assert.Equal(ValidationMode.Strict, e.OldSettings.ValidationMode);
+            Assert.Equal(ValidationMode.Relaxed, e.NewSettings.ValidationMode);
+        };
+        var newSettings = new CoreSettings { ValidationMode = ValidationMode.Relaxed };
+        provider.UpdateSettings(newSettings);
+        Assert.True(raised);
+        var retrieved = provider.GetSettings();
+        Assert.Equal(ValidationMode.Relaxed, retrieved.ValidationMode);
+        Assert.NotSame(newSettings, retrieved);
+    }
+}


### PR DESCRIPTION
## Summary
- expand coverage around configuration and core classes
- test CoreSettingsProvider behavior
- test schema generation option cloning
- add defaults test for KsqlDslOptions
- add extra KsqlContext option extension tests
- cover AvroRetryPolicy invalid values with theory
- confirm KsqlContextOptions validates successfully

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583a769e4c8327b075614f77f222b8