### PR TITLE
Add tests for low coverage functions

### DIFF
--- a/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
+++ b/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
@@ -154,4 +154,22 @@ public class AvroSchemaBuilderDetailedTests
         var json = InvokePrivate<string>(builder, "SerializeSchema", new[] { typeof(AvroSchema) }, null, schema);
         Assert.Contains("name", json);
     }
+
+    [Fact]
+    public void ValidateAvroSchema_ReturnsTrueForValidRecord()
+    {
+        var builder = new AvroSchemaBuilder();
+        var schema = "{ \"type\": \"record\", \"name\": \"T\" }";
+        var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, schema);
+        Assert.True(valid);
+    }
+
+    [Fact]
+    public void ValidateAvroSchema_ReturnsFalseForInvalidRecord()
+    {
+        var builder = new AvroSchemaBuilder();
+        var schema = "{ \"type\": \"record\" }"; // missing name
+        var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, schema);
+        Assert.False(valid);
+    }
 }


### PR DESCRIPTION
## Summary
- improve coverage for AvroSchemaBuilder by testing ValidateAvroSchema
- cover ProjectionBuilder's method calls and operator helper
- test JoinBuilder's private Join finder

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858401e1e548327a0327fca889ae8e5