### PR TITLE
Add tests for low coverage methods

### DIFF
--- a/tests/Query/Builders/HavingBuilderTests.cs
+++ b/tests/Query/Builders/HavingBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using KsqlDsl.Query.Builders;
 using Xunit;
+using static KsqlDsl.Tests.PrivateAccessor;
 
 namespace KsqlDsl.Tests.Query.Builders;
 
@@ -31,5 +32,34 @@ public class HavingBuilderTests
     {
         var builder = new HavingBuilder();
         Assert.Throws<ArgumentNullException>(() => builder.Build(null!));
+    }
+
+    [Theory]
+    [InlineData("LATESTBYOFFSET", "LATEST_BY_OFFSET")]
+    [InlineData("EARLIESTBYOFFSET", "EARLIEST_BY_OFFSET")]
+    [InlineData("COLLECTLIST", "COLLECT_LIST")]
+    [InlineData("COLLECTSET", "COLLECT_SET")]
+    [InlineData("AVERAGE", "AVG")]
+    public void TransformMethodName_ReturnsExpected(string original, string expected)
+    {
+        var result = InvokePrivate<string>(typeof(HavingBuilder), "TransformMethodName", new[] { typeof(string) }, null, original);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(ExpressionType.Equal, "=")]
+    [InlineData(ExpressionType.AndAlso, "AND")]
+    public void GetSqlOperator_ReturnsExpected(ExpressionType type, string expected)
+    {
+        var result = InvokePrivate<string>(typeof(HavingBuilder), "GetSqlOperator", new[] { typeof(ExpressionType) }, null, type);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GetSqlOperator_Unsupported_Throws()
+    {
+        var ex = Assert.Throws<TargetInvocationException>(() =>
+            InvokePrivate<string>(typeof(HavingBuilder), "GetSqlOperator", new[] { typeof(ExpressionType) }, null, ExpressionType.ArrayIndex));
+        Assert.IsType<NotSupportedException>(ex.InnerException);
     }
 }

--- a/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
+++ b/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
@@ -172,4 +172,48 @@ public class AvroSchemaBuilderDetailedTests
         var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, schema);
         Assert.False(valid);
     }
+
+    [Fact]
+    public void ValidateAvroSchema_ReturnsFalseForEmpty()
+    {
+        var builder = new AvroSchemaBuilder();
+        var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, "");
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public void ValidateAvroSchema_ReturnsFalseForInvalidJson()
+    {
+        var builder = new AvroSchemaBuilder();
+        var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, "{");
+        Assert.False(valid);
+    }
+
+    [Fact]
+    public void ValidateAvroSchema_ReturnsTrueForPrimitiveString()
+    {
+        var builder = new AvroSchemaBuilder();
+        var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, "\"int\"");
+        Assert.True(valid);
+    }
+
+    [Fact]
+    public void ValidateAvroSchema_ReturnsTrueForArray()
+    {
+        var builder = new AvroSchemaBuilder();
+        var valid = InvokePrivate<bool>(builder, "ValidateAvroSchema", new[] { typeof(string) }, null, "[1]");
+        Assert.True(valid);
+    }
+
+    [Theory]
+    [InlineData(typeof(decimal), "decimal")]
+    [InlineData(typeof(DateTime), "timestamp-millis")]
+    [InlineData(typeof(Guid), "uuid")]
+    [InlineData(typeof(string), "string")]
+    public void GeneratePrimitiveSchema_ReturnsExpected(Type type, string expected)
+    {
+        var builder = new AvroSchemaBuilder();
+        var json = InvokePrivate<string>(builder, "GeneratePrimitiveSchema", new[] { typeof(Type) }, null, type);
+        Assert.Contains(expected, json);
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for primitive key serializers in `AvroSerializerFactory`
- extend `AvroSchemaBuilderDetailedTests` for more branches
- test helper methods in `HavingBuilder`
- expand `JoinBuilder` tests to cover more expression types

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685842761618832791e2a34756d10407