### PR TITLE
Fix missing using for TargetInvocationException

### DIFF
--- a/tests/Query/Builders/HavingBuilderTests.cs
+++ b/tests/Query/Builders/HavingBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using KsqlDsl.Query.Builders;
 using Xunit;
 using static KsqlDsl.Tests.PrivateAccessor;


### PR DESCRIPTION
## Summary
- fix compile error in HavingBuilderTests by importing `System.Reflection`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858443e5ce48327b01a6d977217d2ec