### PR TITLE
Fix Kafka config test

### DIFF
--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -1,4 +1,5 @@
 using Confluent.SchemaRegistry;
+using Confluent.Kafka;
 using KsqlDsl.Configuration;
 using KsqlDsl.Messaging.Configuration;
 using KsqlDsl.Messaging.Producers;
@@ -27,5 +28,31 @@ public class KafkaProducerManagerExtraTests
         var manager = new KafkaProducerManager(Options.Create(options), null);
         var client = InvokePrivate<object>(manager, "CreateSchemaRegistryClient", System.Type.EmptyTypes);
         Assert.Equal("CachedSchemaRegistryClient", client!.GetType().Name);
+    }
+
+    [Fact]
+    public void BuildProducerConfig_IncludesAdditionalProperties()
+    {
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection { BootstrapServers = "b" },
+            Topics = new System.Collections.Generic.Dictionary<string, TopicSection>
+            {
+                ["topic"] = new TopicSection
+                {
+                    Producer = new ProducerSection
+                    {
+                        AdditionalProperties = new System.Collections.Generic.Dictionary<string, string>
+                        {
+                            ["prop"] = "val"
+                        }
+                    }
+                }
+            }
+        };
+        var manager = new KafkaProducerManager(Options.Create(options), null);
+        var config = InvokePrivate<ProducerConfig>(manager, "BuildProducerConfig", new[] { typeof(string) }, null, "topic");
+        Assert.True(config.TryGet("prop", out var value));
+        Assert.Equal("val", value);
     }
 }


### PR DESCRIPTION
## Summary
- test that BuildProducerConfig includes custom properties
- bring in Confluent.Kafka to tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68587c7db91083279d45d5b478270288