### PR TITLE
Fix ProducerConfig property access

### DIFF
--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -73,7 +73,7 @@ public class KafkaProducerManagerExtraTests
         Assert.Equal("cert", config.SslCertificateLocation);
         Assert.Equal("key", config.SslKeyLocation);
         Assert.Equal("kp", config.SslKeyPassword);
-        Assert.True(config.TryGetValue("partitioner.class", out var part));
+        Assert.True(config.TryGet("partitioner.class", out var part));
         Assert.Equal("m", part);
     }
 


### PR DESCRIPTION
## Summary
- correct property retrieval in KafkaProducerManagerExtraTests

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68587dd1e1608327a99cc16caf163392