### PR TITLE
Add join unit tests

### DIFF
--- a/tests/Query/JoinBuilderTests.cs
+++ b/tests/Query/JoinBuilderTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace KsqlDsl.Tests.Query;
+
+public class JoinBuilderTests
+{
+    [Fact]
+    public void TwoTableJoin_AllKeysMatch_ReturnsJoinedRecords()
+    {
+        var a = new List<TestEntity>
+        {
+            new TestEntity { Id = 1, Name = "A1" }
+        };
+        var b = new List<ChildEntity>
+        {
+            new ChildEntity { Id = 10, ParentId = 1, Name = "B1" }
+        };
+
+        var result = a.Join(b, x => x.Id, y => y.ParentId, (x, y) => new
+        {
+            AName = x.Name,
+            BName = y.Name
+        }).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("A1", result[0].AName);
+        Assert.Equal("B1", result[0].BName);
+    }
+
+    [Fact]
+    public void TwoTableJoin_KeyMismatch_ReturnsEmpty()
+    {
+        var a = new List<TestEntity>
+        {
+            new TestEntity { Id = 1, Name = "A1" }
+        };
+        var b = new List<ChildEntity>
+        {
+            new ChildEntity { Id = 10, ParentId = 2, Name = "B1" }
+        };
+
+        var result = a.Join(b, x => x.Id, y => y.ParentId, (x, y) => new
+        {
+            AName = x.Name,
+            BName = y.Name
+        }).ToList();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ThreeTableJoin_AllKeysMatch_ReturnsJoinedRecords()
+    {
+        var a = new List<TestEntity>
+        {
+            new TestEntity { Id = 1, Name = "A1" }
+        };
+        var b = new List<ChildEntity>
+        {
+            new ChildEntity { Id = 10, ParentId = 1, Name = "B1" }
+        };
+        var c = new List<GrandChildEntity>
+        {
+            new GrandChildEntity { Id = 100, ChildId = 10, Description = "C1" }
+        };
+
+        var result = a.Join(b, x => x.Id, y => y.ParentId, (x, y) => new { x, y })
+            .Join(c, ab => ab.y.Id, z => z.ChildId, (ab, z) => new
+            {
+                AName = ab.x.Name,
+                BName = ab.y.Name,
+                CDesc = z.Description
+            }).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("A1", result[0].AName);
+        Assert.Equal("B1", result[0].BName);
+        Assert.Equal("C1", result[0].CDesc);
+    }
+
+    [Fact]
+    public void ThreeTableJoin_KeyMismatch_ReturnsEmpty()
+    {
+        var a = new List<TestEntity>
+        {
+            new TestEntity { Id = 1, Name = "A1" }
+        };
+        var b = new List<ChildEntity>
+        {
+            new ChildEntity { Id = 10, ParentId = 1, Name = "B1" }
+        };
+        var c = new List<GrandChildEntity>
+        {
+            new GrandChildEntity { Id = 100, ChildId = 20, Description = "C1" }
+        };
+
+        var result = a.Join(b, x => x.Id, y => y.ParentId, (x, y) => new { x, y })
+            .Join(c, ab => ab.y.Id, z => z.ChildId, (ab, z) => new
+            {
+                AName = ab.x.Name,
+                BName = ab.y.Name,
+                CDesc = z.Description
+            }).ToList();
+
+        Assert.Empty(result);
+    }
+}

--- a/tests/Query/TestEntities.cs
+++ b/tests/Query/TestEntities.cs
@@ -18,6 +18,13 @@ public class ChildEntity
     public string Name { get; set; } = string.Empty;
 }
 
+public class GrandChildEntity
+{
+    public int Id { get; set; }
+    public int ChildId { get; set; }
+    public string Description { get; set; } = string.Empty;
+}
+
 public class WindowDef
 {
     public WindowDef TumblingWindow() => this;


### PR DESCRIPTION
## Summary
- add JoinBuilderTests for join logic covering success and mismatch cases
- add GrandChildEntity test type for 3 table joins

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685880e58f688327b098a70b3826351c