### PR TITLE
Fix missing namespace in KsqlDbRestApiClientTests

### DIFF
--- a/tests/Query/Ksql/KsqlDbRestApiClientTests.cs
+++ b/tests/Query/Ksql/KsqlDbRestApiClientTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System; // For Func
 using System.Threading;
 using System.Threading.Tasks;
 using KsqlDsl.Query.Ksql;


### PR DESCRIPTION
## Summary
- include `System` using directive so Func<> resolves

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588494e5388327813e026b22ffdbe1