### PR TITLE
Fix build by adding System.Reflection in test

### DIFF
--- a/tests/Messaging/Consumers/KafkaConsumerTests.cs
+++ b/tests/Messaging/Consumers/KafkaConsumerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Reflection;
 using Confluent.Kafka;
 using KsqlDsl.Configuration.Abstractions;
 using KsqlDsl.Core.Abstractions;


### PR DESCRIPTION
## Summary
- add missing `System.Reflection` using in KafkaConsumerTests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588568830c83279e2e055e72ef8908