### PR TITLE
Add tests for state store helpers

### DIFF
--- a/tests/StateStore/EventSetWithStateStoreKeyTests.cs
+++ b/tests/StateStore/EventSetWithStateStoreKeyTests.cs
@@ -1,0 +1,87 @@
+using KsqlDsl;
+using KsqlDsl.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace KsqlDsl.Tests.StateStore;
+
+public class EventSetWithStateStoreKeyTests
+{
+    private class DummyContext : IKafkaContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class Sample
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public int PartA { get; set; }
+        public int PartB { get; set; }
+    }
+
+    private static EntityModel ModelWithKeys(params string[] keyNames)
+    {
+        var all = typeof(Sample).GetProperties();
+        var keys = new List<System.Reflection.PropertyInfo>();
+        foreach (var name in keyNames)
+        {
+            keys.Add(typeof(Sample).GetProperty(name)!);
+        }
+        return new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicAttribute = new TopicAttribute("t"),
+            AllProperties = all,
+            KeyProperties = keys.ToArray()
+        };
+    }
+
+    private static string GenerateKey(EntityModel model, Sample? entity)
+    {
+        var set = new EventSetWithStateStore<Sample>(new DummyContext(), model);
+        return PrivateAccessor.InvokePrivate<string>(set, "GenerateEntityKey", new[] { typeof(Sample) }, args: new object?[] { entity });
+    }
+
+    [Fact]
+    public void GenerateEntityKey_NullEntity_ReturnsGuidLike()
+    {
+        var model = ModelWithKeys("Id");
+        var key = GenerateKey(model, null);
+        Assert.False(string.IsNullOrEmpty(key));
+        Guid.Parse(key); // should be valid guid
+    }
+
+    [Fact]
+    public void GenerateEntityKey_NoKeyProperties_UsesHashCode()
+    {
+        var model = ModelWithKeys();
+        var entity = new Sample { Id = 1 };
+        var key = GenerateKey(model, entity);
+        Assert.Equal(entity.GetHashCode().ToString(), key);
+    }
+
+    [Fact]
+    public void GenerateEntityKey_SingleKeyProperty_UsesValue()
+    {
+        var model = ModelWithKeys("Id");
+        var entity = new Sample { Id = 123 };
+        var key = GenerateKey(model, entity);
+        Assert.Equal("123", key);
+    }
+
+    [Fact]
+    public void GenerateEntityKey_MultipleKeys_ConcatenatesValues()
+    {
+        var model = ModelWithKeys("PartA", "PartB");
+        var entity = new Sample { PartA = 1, PartB = 2 };
+        var key = GenerateKey(model, entity);
+        Assert.Equal("1|2", key);
+    }
+}

--- a/tests/StateStore/ReadyStateInfoTests.cs
+++ b/tests/StateStore/ReadyStateInfoTests.cs
@@ -1,0 +1,49 @@
+using KsqlDsl.StateStore.Monitoring;
+using System;
+using Xunit;
+
+namespace KsqlDsl.Tests.StateStore;
+
+public class ReadyStateInfoTests
+{
+    [Fact]
+    public void ToString_ReadyStateIncludesTimeToReady()
+    {
+        var info = new ReadyStateInfo
+        {
+            TopicName = "topic",
+            IsReady = true,
+            TotalLag = 10,
+            PartitionCount = 2,
+            TimeToReady = TimeSpan.FromSeconds(5)
+        };
+
+        var text = info.ToString();
+
+        Assert.Contains("topic", text);
+        Assert.Contains("READY", text);
+        Assert.Contains("10", text);
+        Assert.Contains("Partitions: 2", text);
+        Assert.Contains("Ready in: 5.0s", text);
+    }
+
+    [Fact]
+    public void ToString_NotReadyIncludesBindingTime()
+    {
+        var info = new ReadyStateInfo
+        {
+            TopicName = "t2",
+            IsReady = false,
+            TotalLag = 3,
+            PartitionCount = 1,
+            TimeSinceBinding = TimeSpan.FromSeconds(7)
+        };
+
+        var text = info.ToString();
+
+        Assert.Contains("t2", text);
+        Assert.Contains("NOT_READY", text);
+        Assert.Contains("3", text);
+        Assert.Contains("Binding for: 7.0s", text);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `EventSetWithStateStore` key generation logic
- test `ReadyStateInfo.ToString` formatting

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ec9831c883278c657b9965f87970