### PR TITLE
Fix missing EventSetWithStateStore using

### DIFF
--- a/tests/StateStore/EventSetWithStateStoreKeyTests.cs
+++ b/tests/StateStore/EventSetWithStateStoreKeyTests.cs
@@ -1,5 +1,6 @@
 using KsqlDsl;
 using KsqlDsl.Core.Abstractions;
+using KsqlDsl.StateStore;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- include `KsqlDsl.StateStore` namespace in EventSetWithStateStoreKeyTests

## Testing
- `dotnet test tests/KsqlDslTests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f02a62f48327900546da659b7306