### PR TITLE
Fix topic attribute segment bytes type

### DIFF
--- a/src/Core/Abstractions/TopicAttribute.cs
+++ b/src/Core/Abstractions/TopicAttribute.cs
@@ -48,7 +48,7 @@ public class TopicAttribute : Attribute
             config["max.message.bytes"] = MaxMessageBytes.Value;
 
         if (SegmentBytes.HasValue)
-            config["segment.bytes"] = SegmentBytes.Value;
+            config["segment.bytes"] = (int)SegmentBytes.Value;
 
         return config;
     }


### PR DESCRIPTION
## Summary
- convert segment byte assignment to int when building topic config

## Testing
- `dotnet test --no-build tests/KsqlDsl.Tests/KsqlDsl.Tests.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859f535c5488327bc78d27350ad0ecb