### PR TITLE
Fix test visibility

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -4,4 +4,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Kafka.Ksql.LinqTests")]
 [assembly: InternalsVisibleTo("Kafka.Ksql.Linq.Tests")]
 [assembly: InternalsVisibleTo("Kafka.Ksql.Linq.Tests.Integration")]
+[assembly: InternalsVisibleTo("KsqlDsl.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
## Summary
- expose internal code to the `KsqlDsl.Tests` assembly

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f81bedcc8327a21d911b0cfe9ac9