### PR TITLE
Fix reflection for CoreValidationResult test

### DIFF
--- a/tests/Core/CoreValidationResultTests.cs
+++ b/tests/Core/CoreValidationResultTests.cs
@@ -7,7 +7,11 @@ namespace Kafka.Ksql.Linq.Tests.Core;
 
 public class CoreValidationResultTests
 {
-    private static Type GetTypeRef() => Type.GetType("Kafka.Ksql.Linq.Core.Validation.CoreValidationResult, Kafka.Ksql.Linq")!;
+    private static Type GetTypeRef()
+    {
+        var asm = typeof(Kafka.Ksql.Linq.Core.Abstractions.ValidationResult).Assembly;
+        return asm.GetType("Kafka.Ksql.Linq.Core.Validation.CoreValidationResult")!;
+    }
 
     [Fact]
     public void Properties_CanBeSetViaReflection()


### PR DESCRIPTION
## Summary
- fix assembly name when obtaining CoreValidationResult via reflection

## Testing
- `dotnet test --no-build tests/KsqlDslTests.csproj -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f968aac88327ab17257241142a09