### PR TITLE
Fix access modifier for BigBang scenario record

### DIFF
--- a/tests/Query/Builders/BigBangScenarioTests.cs
+++ b/tests/Query/Builders/BigBangScenarioTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
-private record OrderCustomerInfo(DateTime OrderDate, decimal TotalAmount, string? Region);
+public record OrderCustomerInfo(DateTime OrderDate, decimal TotalAmount, string? Region);
 
 public class BigBangScenarioTests
 {


### PR DESCRIPTION
## Summary
- change `OrderCustomerInfo` record in BigBangScenarioTests to `public`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a00f3c5448327ad09411dfa0ee611