### PR TITLE
Fix expected clause in BigBangScenarioTests

### DIFF
--- a/tests/Query/Builders/BigBangScenarioTests.cs
+++ b/tests/Query/Builders/BigBangScenarioTests.cs
@@ -43,7 +43,7 @@ public class BigBangScenarioTests
         var final = $"{joinSql} {whereSql} {windowSql} {groupSql}";
 
         Assert.Contains("JOIN Customer", final);
-        Assert.Contains("WHERE ((TotalAmount > 100) AND (Region <> NULL))", final);
+        Assert.Contains("WHERE ((TotalAmount > 100) AND Region IS NOT NULL)", final);
         Assert.Contains("WINDOW TUMBLING (SIZE 1 DAYS)", final);
         Assert.Contains("GROUP BY OrderDate", final);
     }


### PR DESCRIPTION
## Summary
- update assertion in `BigBangScenarioTests` to match generated KSQL

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0ddecd888327b7355fd044d21333