### PR TITLE
Rename csproj and solution

### DIFF
--- a/Kafka.Ksql.Linq.sln
+++ b/Kafka.Ksql.Linq.sln
@@ -5,11 +5,11 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KsqlDsl", "src\KsqlDsl.csproj", "{FCFDE22B-6223-4B42-8818-C3914DEC8B43}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kafka.Ksql.Linq", "src\Kafka.Ksql.Linq.csproj", "{FCFDE22B-6223-4B42-8818-C3914DEC8B43}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KsqlDslTests", "tests\KsqlDslTests.csproj", "{CDD782BE-B899-4E79-8836-FC312129B2EF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kafka.Ksql.Linq.Tests", "tests\Kafka.Ksql.Linq.Tests.csproj", "{CDD782BE-B899-4E79-8836-FC312129B2EF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Kafka.Ksql.LinqTests")]
 [assembly: InternalsVisibleTo("Kafka.Ksql.Linq.Tests")]
 [assembly: InternalsVisibleTo("Kafka.Ksql.Linq.Tests.Integration")]
-[assembly: InternalsVisibleTo("KsqlDsl.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Kafka.Ksql.Linq.csproj
+++ b/src/Kafka.Ksql.Linq.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Kafka.Ksql.Linq</RootNamespace>
+    <AssemblyName>Kafka.Ksql.Linq</AssemblyName>
     <!-- ✅ Nullable Reference Types を有効化 -->
     <Nullable>enable</Nullable>
     <!-- ✅ 警告をエラーとして扱う (開発時品質向上) -->

--- a/tests/Kafka.Ksql.Linq.Tests.csproj
+++ b/tests/Kafka.Ksql.Linq.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyName>KsqlDsl.Tests</AssemblyName>
+    <AssemblyName>Kafka.Ksql.Linq.Tests</AssemblyName>
     <RootNamespace>Kafka.Ksql.Linq.Tests</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <ProjectReference Include="../src/KsqlDsl.csproj" />
+    <ProjectReference Include="../src/Kafka.Ksql.Linq.csproj" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />


### PR DESCRIPTION
## Summary
- specify explicit `AssemblyName` in the main project
- solution and tests already reference `Kafka.Ksql.Linq`
- visibility attributes target the new test assembly

## Testing
- `dotnet test Kafka.Ksql.Linq.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a16d2b3b8832784ace0f703c49ddc