### PR TITLE
Apply internal visibility to CoreLayerValidation

### DIFF
--- a/src/Core/CoreLayerValidation.cs
+++ b/src/Core/CoreLayerValidation.cs
@@ -13,7 +13,7 @@ namespace Kafka.Ksql.Linq.Core;
 /// 設計理由：依存関係の一方向性確保
 /// 修正理由：重複削除による参照更新
 /// </summary>
-public static class CoreLayerValidation
+internal static class CoreLayerValidation
 {
     private static readonly string[] ForbiddenNamespaces = new[]
     {

--- a/task/visibility_analysis_report2.md
+++ b/task/visibility_analysis_report2.md
@@ -362,13 +362,13 @@ public interface IEntitySet<T>
 ## 📋 実装チェックリスト
 
 ### Phase 1 (安全確実・即実行可能)
-- [ ] `KeyExtractor` → internal static
-- [ ] `ProducerKey` → internal  
-- [ ] `CoreSettings` → internal
-- [ ] `CoreDependencyConfiguration` → internal static
-- [ ] `CoreLayerPhase3Marker` → internal static
-- [ ] `TopicOverrideService` → internal
-- [ ] REST APIクラス群(5個) → internal
+- [x] `KeyExtractor` → internal static
+- [x] `ProducerKey` → internal
+- [x] `CoreSettings` → internal
+- [x] `CoreDependencyConfiguration` → internal static
+- [x] `CoreLayerPhase3Marker` → internal static
+- [x] `TopicOverrideService` → internal
+- [x] REST APIクラス群(5個) → internal
 
 ### Phase 2 (Builder群)
 - [ ] `GroupByBuilder` → internal


### PR DESCRIPTION
## Summary
- mark CoreLayerValidation as internal
- record completion for Phase 1 items in visibility checklist

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd70052448327b76e023a65503dd5