### PR TITLE
Fix ReadyStateMonitor design gap

### DIFF
--- a/docs/diff_log/diff_ready_state_monitor_20250627.md
+++ b/docs/diff_log/diff_ready_state_monitor_20250627.md
@@ -1,0 +1,18 @@
+# 差分履歴: ReadyStateMonitor
+
+🗕 2025年6月27日（JST）
+🧐 作業者: 鏡花（品質監査AI）
+
+## 差分タイトル
+StateStore同期監視フローの設計追記
+
+## 変更理由
+`diff_overall_20250626.md` で指摘された ReadyStateMonitor の設計欠落を解消するため
+
+## 追加・修正内容（反映先: oss_design_combined.md）
+- セクション 10.5 「ReadyStateMonitor による Lag 監視と Ready 判定」を新設
+- `TopicStateStoreBinding` 生成時に自動起動するモニタリングの概要を説明
+- Lag 計測ロジックと `ReadyStateChanged` イベントの利用例を追記
+
+## 参考文書
+- `docs_advanced_rules.md` セクション 2

--- a/docs/oss_design_combined.md
+++ b/docs/oss_design_combined.md
@@ -776,6 +776,26 @@ Kafka インフラ未構築でも開発可能：先に LINQ や POCO を定義�
 
 学習コスト低減：Kafka 環境のセットアップを待たずに、DSL定義の学習・試行錯誤が可能。。
 
+### 10.5 ReadyStateMonitor による Lag 監視と Ready 判定
+
+StateStore バインディングでは、Kafka コンシューマの Lag を定期的に計測し、完全に追いついた時点を
+"Ready" として通知する `ReadyStateMonitor` を使用します。`TopicStateStoreBinding` 生成時に
+内部でこのモニターが起動し、5 秒間隔で `QueryWatermarkOffsets` と `Position` を照会して Lag を
+計算します。Lag が 0 になると `ReadyStateChanged` イベントが発火し、`WaitUntilReadyAsync` が完了
+します。
+
+```csharp
+// バインディング作成後に同期完了を待機
+var binding = await manager.CreateBindingAsync(stateStore, consumer, entityModel);
+var ready = await binding.WaitUntilReadyAsync(TimeSpan.FromMinutes(5));
+if (!ready) throw new TimeoutException("StateStore sync timed out.");
+
+var info = binding.GetReadyStateInfo();
+Console.WriteLine($"Lag:{info.TotalLag} Ready:{info.IsReady}");
+```
+
+詳細フローやクラス構成は `docs/namespaces/statestore_namespace_doc.md` の Monitoring セクションを参照してください。
+
 
 ## 11. Kafkaのcommit/DB commit・障害時の動作（DBエンジニア必読）
 


### PR DESCRIPTION
## Summary
- document the ReadyStateMonitor monitoring flow
- add diff log for ReadyStateMonitor design

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de1cc944483279d0e47ce29283d7e