### PR TITLE
fix build error for CoreSettings

### DIFF
--- a/src/Core/Configuration/CoreSettings.cs
+++ b/src/Core/Configuration/CoreSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Exceptions;
+using System;
 
 namespace Kafka.Ksql.Linq.Core.Configuration;
 

--- a/tests/Core/CoreSettingsProviderTests.cs
+++ b/tests/Core/CoreSettingsProviderTests.cs
@@ -34,7 +34,13 @@ public class CoreSettingsProviderTests
             Assert.Equal(ValidationMode.Strict, e.OldSettings.ValidationMode);
             Assert.Equal(ValidationMode.Relaxed, e.NewSettings.ValidationMode);
         };
-        var newSettings = new CoreSettings { ValidationMode = ValidationMode.Relaxed };
+        var newSettings = new CoreSettings
+        {
+            ValidationMode = ValidationMode.Relaxed,
+            KafkaBootstrapServers = "localhost:9092",
+            ApplicationId = "app",
+            StateStoreDirectory = "/tmp"
+        };
         provider.UpdateSettings(newSettings);
         Assert.True(raised);
         var retrieved = provider.GetSettings();

--- a/tests/KsqlDslTests/CoreSettingsTests.cs
+++ b/tests/KsqlDslTests/CoreSettingsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Kafka.Ksql.Linq.Core.Configuration;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- import `System` namespace in `CoreSettings.cs`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685deecdbba48327bdc4b9f5d5251103