### PR TITLE
Fix missing System.Linq using

### DIFF
--- a/tests/KsqlDslTests/Aggregate/LateEarliestOffsetTests.cs
+++ b/tests/KsqlDslTests/Aggregate/LateEarliestOffsetTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Query.Builders;
 using Xunit;


### PR DESCRIPTION
## Summary
- add `System.Linq` using directive for LateEarliestOffsetTests

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df497c5e48327aa3cd144ce9f527d