### PR TITLE
Add implement_diff coverage tracking

### DIFF
--- a/docs/implement_status.md
+++ b/docs/implement_status.md
@@ -1,0 +1,12 @@
+# 実装カバレッジ状況
+
+`task/implement-diff.txt` の未対応項目を基準に、現在の実装状況と担当タスクを一覧化する。
+
+| 機能 | 状況 | 対応タスク名 | 備考 |
+|---|---|---|---|
+| OnError → Map → Retry | ✅ 実装済 | - | `EventSetErrorHandlingExtensions.cs` で確認済 |
+| LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ⏳ 実装中 | ksql_offset_aggregates | プレースホルダのみ |
+| DLQ設定（ModelBuilder） | ⏳ 部分実装 | dlq_configuration_support | `TopicAttribute` 定義はある |
+| HasTopic API | ❌ 未実装 | has_topic_api_extension | ModelBuilder拡張が未着手 |
+| ManualCommit切替 | ⏳ 不完全 | manual_commit_extension | 分岐・Ack操作なし |
+| char/shortサポート | ❌ 未実装 | special_type_handling | 警告・自動変換未実装 |

--- a/tasks/chainable_error_dsl/README.md
+++ b/tasks/chainable_error_dsl/README.md
@@ -1,0 +1,1 @@
+# chainable_error_dsl

--- a/tasks/deserialization_error_policy/README.md
+++ b/tasks/deserialization_error_policy/README.md
@@ -1,0 +1,1 @@
+# deserialization_error_policy

--- a/tasks/dlq_configuration_support/README.md
+++ b/tasks/dlq_configuration_support/README.md
@@ -1,0 +1,1 @@
+# dlq_configuration_support

--- a/tasks/foreach_trycatch_support/README.md
+++ b/tasks/foreach_trycatch_support/README.md
@@ -1,0 +1,1 @@
+# foreach_trycatch_support

--- a/tasks/has_topic_api_extension/README.md
+++ b/tasks/has_topic_api_extension/README.md
@@ -1,0 +1,1 @@
+# has_topic_api_extension

--- a/tasks/implement_diff_completion/coverage.md
+++ b/tasks/implement_diff_completion/coverage.md
@@ -1,0 +1,23 @@
+# ✏️ カバレッジ進行状況
+
+下表は `task/implement-diff.txt` の未実装または部分実装項目について、現在のカバレッジ状況を整理したものです。
+
+| 機能カテゴリ | 機能 | 状況 | 対応タスク名 | 備考 |
+| --- | --- | --- | --- | --- |
+| Topics | Fluent APIによるトピック設定 | ❌ 未実装 | topic_fluent_api_extension | Partitions/Replication設定未対応 |
+| Topics | パーティショニング戦略設定 | ❌ 未実装 | topic_fluent_api_extension | | 
+| Topics | ISRの最小数設定 | ❌ 未実装 | topic_fluent_api_extension | |
+| Streams | Window DSL機能 | ❌ 未実装 | window_dsl_feature | TumblingWindow等 |
+| Streams | 購読モードの固定化制御 | ⏳ 部分実装 | subscription_mode_fixed | UseManualCommitの実行時切替未実装 |
+| Tables | LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ⏳ 実装中 | ksql_offset_aggregates | プレースホルダあり |
+| Tables | 複数ウィンドウ定義とアクセス | ❌ 未実装 | multi_window_access | |
+| Tables | HasTopic()メソッド | ❌ 未実装 | has_topic_api_extension | |
+| Tables | WindowStart / WindowEndプロパティ | ❌ 未実装 | window_start_end_support | |
+| Query & Subscription | 手動コミット購読処理の型分岐 | ⏳ 不完全 | manual_commit_extension | Ack操作・型分岐不足 |
+| Query & Subscription | 購読処理の完全実装 | ❌ 未実装 | manual_commit_extension | CommitAsync等未実装 |
+| Query & Subscription | yield型ForEachAsyncでのtry-catch | ❌ 未実装 | foreach_trycatch_support | |
+| Special Types | char型警告 | ❌ 未実装 | special_type_handling | 警告処理なし |
+| Special Types | short型自動int変換 | ❌ 未実装 | special_type_handling | 変換処理不明確 |
+| Error Handling | チェーン可能なエラー処理DSL | ⏳ 部分実装 | chainable_error_dsl | OnError→Map→Retryの連鎖未完成 |
+| Error Handling | デシリアライズエラーポリシー | ❌ 未実装 | deserialization_error_policy | |
+| Error Handling | ModelBuilderでのDLQ設定 | ⏳ 部分実装 | dlq_configuration_support | TopicAttributeには存在 |

--- a/tasks/implement_diff_completion/worklog.md
+++ b/tasks/implement_diff_completion/worklog.md
@@ -1,0 +1,17 @@
+# implement_diff_completion Worklog
+
+This task consolidates coverage status for items listed in `task/implement-diff.txt` and creates subtasks for missing or partial features.
+
+## Created Subtask Directories
+- topic_fluent_api_extension
+- window_dsl_feature
+- subscription_mode_fixed
+- multi_window_access
+- has_topic_api_extension
+- window_start_end_support
+- manual_commit_extension
+- foreach_trycatch_support
+- special_type_handling
+- chainable_error_dsl
+- dlq_configuration_support
+- deserialization_error_policy

--- a/tasks/manual_commit_extension/README.md
+++ b/tasks/manual_commit_extension/README.md
@@ -1,0 +1,1 @@
+# manual_commit_extension

--- a/tasks/multi_window_access/README.md
+++ b/tasks/multi_window_access/README.md
@@ -1,0 +1,1 @@
+# multi_window_access

--- a/tasks/special_type_handling/README.md
+++ b/tasks/special_type_handling/README.md
@@ -1,0 +1,1 @@
+# special_type_handling

--- a/tasks/subscription_mode_fixed/README.md
+++ b/tasks/subscription_mode_fixed/README.md
@@ -1,0 +1,1 @@
+# subscription_mode_fixed

--- a/tasks/topic_fluent_api_extension/README.md
+++ b/tasks/topic_fluent_api_extension/README.md
@@ -1,0 +1,1 @@
+# topic_fluent_api_extension

--- a/tasks/window_dsl_feature/README.md
+++ b/tasks/window_dsl_feature/README.md
@@ -1,0 +1,1 @@
+# window_dsl_feature

--- a/tasks/window_start_end_support/README.md
+++ b/tasks/window_start_end_support/README.md
@@ -1,0 +1,1 @@
+# window_start_end_support


### PR DESCRIPTION
## Summary
- create implement_diff_completion task with coverage tables
- scaffold subtasks for missing features
- add docs/implement_status.md with current coverage snapshot

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df8c344e88327981b8e0fd552981e