### PR TITLE
Finalize offset aggregate docs

### DIFF
--- a/docs/implement_status.md
+++ b/docs/implement_status.md
@@ -5,7 +5,7 @@
 | 機能 | 状況 | 対応タスク名 | 備考 |
 |---|---|---|---|
 | OnError → Map → Retry | ✅ 実装済 | - | `EventSetErrorHandlingExtensions.cs` で確認済 |
-| LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ⏳ 実装中 | ksql_offset_aggregates | プレースホルダのみ |
+| LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ✅ 実装済 | ksql_offset_aggregates | ProjectionBuilder, WindowAggregatedEntitySet 対応 |
 | DLQ設定（ModelBuilder） | ⏳ 部分実装 | dlq_configuration_support | `TopicAttribute` 定義はある |
 | HasTopic API | ❌ 未実装 | has_topic_api_extension | ModelBuilder拡張が未着手 |
 | ManualCommit切替 | ⏳ 不完全 | manual_commit_extension | 分岐・Ack操作なし |

--- a/tasks/implement_diff_completion/coverage.md
+++ b/tasks/implement_diff_completion/coverage.md
@@ -9,7 +9,7 @@
 | Topics | ISRの最小数設定 | ❌ 未実装 | topic_fluent_api_extension | |
 | Streams | Window DSL機能 | ❌ 未実装 | window_dsl_feature | TumblingWindow等 |
 | Streams | 購読モードの固定化制御 | ⏳ 部分実装 | subscription_mode_fixed | UseManualCommitの実行時切替未実装 |
-| Tables | LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ⏳ 実装中 | ksql_offset_aggregates | プレースホルダあり |
+| Tables | LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ✅ 実装済 | ksql_offset_aggregates | ProjectionBuilderで変換完了 |
 | Tables | 複数ウィンドウ定義とアクセス | ❌ 未実装 | multi_window_access | |
 | Tables | HasTopic()メソッド | ❌ 未実装 | has_topic_api_extension | |
 | Tables | WindowStart / WindowEndプロパティ | ❌ 未実装 | window_start_end_support | |

--- a/tasks/ksql_offset_aggregates/worklog.md
+++ b/tasks/ksql_offset_aggregates/worklog.md
@@ -3,3 +3,4 @@
 - Extended ProjectionBuilder to translate new aggregate functions.
 - Extended WindowAggregatedEntitySet aggregation visitor to output LATEST_BY_OFFSET and EARLIEST_BY_OFFSET.
 - Created unit tests verifying KSQL translation.
+- Updated coverage docs to mark this feature as completed.


### PR DESCRIPTION
## Summary
- mark LATEST_BY_OFFSET/EARLIEST_BY_OFFSET feature as complete in docs
- record completion in ksql_offset_aggregates worklog

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dff5cbacc83278a4cc16e346fff19