### PR TITLE
Add fluent API for topic configuration

### DIFF
--- a/src/Core/Modeling/EntityBuilderTopicExtensions.cs
+++ b/src/Core/Modeling/EntityBuilderTopicExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using Kafka.Ksql.Linq.Core.Abstractions;
+
+namespace Kafka.Ksql.Linq.Core.Modeling;
+
+/// <summary>
+/// Extensions to expose topic configuration fluent API on <see cref="IEntityBuilder{T}"/>.
+/// </summary>
+public static class EntityBuilderTopicExtensions
+{
+    public static IEntityBuilder<T> HasTopic<T>(this IEntityBuilder<T> builder, string topicName) where T : class
+    {
+        if (builder is not EntityModelBuilder<T> concrete)
+            throw new ArgumentException("Invalid builder type", nameof(builder));
+        return concrete.HasTopic(topicName);
+    }
+
+    public static IEntityBuilder<T> WithPartitions<T>(this IEntityBuilder<T> builder, int partitions) where T : class
+    {
+        if (builder is not EntityModelBuilder<T> concrete)
+            throw new ArgumentException("Invalid builder type", nameof(builder));
+        return concrete.WithPartitions(partitions);
+    }
+
+    public static IEntityBuilder<T> WithReplicationFactor<T>(this IEntityBuilder<T> builder, int replicationFactor) where T : class
+    {
+        if (builder is not EntityModelBuilder<T> concrete)
+            throw new ArgumentException("Invalid builder type", nameof(builder));
+        return concrete.WithReplicationFactor(replicationFactor);
+    }
+}
+

--- a/tests/ModelBuilderTests/TopicFluentApiTests.cs
+++ b/tests/ModelBuilderTests/TopicFluentApiTests.cs
@@ -1,0 +1,30 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.ModelBuilderTests;
+
+public class TopicFluentApiTests
+{
+    private class Order
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void FluentApi_ConfiguresTopicSettings()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<Order>()
+            .HasTopic("orders")
+            .WithPartitions(3)
+            .WithReplicationFactor(2);
+
+        var model = builder.GetEntityModel<Order>();
+        Assert.NotNull(model.TopicAttribute);
+        Assert.Equal("orders", model.TopicAttribute!.TopicName);
+        Assert.Equal(3, model.TopicAttribute.PartitionCount);
+        Assert.Equal(2, model.TopicAttribute.ReplicationFactor);
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring Kafka topic name, partitions, and replication factor via `EntityModelBuilder`
- add tests covering the new fluent API

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0bf27f948327b48187669fb6fc9d