### PR TITLE
Update coverage after topic API work

### DIFF
--- a/docs/implement_status.md
+++ b/docs/implement_status.md
@@ -7,6 +7,6 @@
 | OnError → Map → Retry | ✅ 実装済 | - | `EventSetErrorHandlingExtensions.cs` で確認済 |
 | LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ✅ 実装済 | ksql_offset_aggregates | ProjectionBuilder, WindowAggregatedEntitySet 対応 |
 | DLQ設定（ModelBuilder） | ⏳ 部分実装 | dlq_configuration_support | `TopicAttribute` 定義はある |
-| HasTopic API | ❌ 未実装 | has_topic_api_extension | ModelBuilder拡張が未着手 |
+| HasTopic API | ✅ 実装済 | has_topic_api_extension | EntityBuilderTopicExtensions|
 | ManualCommit切替 | ⏳ 不完全 | manual_commit_extension | 分岐・Ack操作なし |
 | char/shortサポート | ❌ 未実装 | special_type_handling | 警告・自動変換未実装 |

--- a/tasks/implement_diff_completion/coverage.md
+++ b/tasks/implement_diff_completion/coverage.md
@@ -4,17 +4,17 @@
 
 | 機能カテゴリ | 機能 | 状況 | 対応タスク名 | 備考 |
 | --- | --- | --- | --- | --- |
-| Topics | Fluent APIによるトピック設定 | ❌ 未実装 | topic_fluent_api_extension | Partitions/Replication設定未対応 |
+| Topics | Fluent APIによるトピック設定 | ✅ 実装済 | topic_fluent_api_extension | EntityModelBuilder, extension methods |
 | Topics | パーティショニング戦略設定 | ❌ 未実装 | topic_fluent_api_extension | | 
 | Topics | ISRの最小数設定 | ❌ 未実装 | topic_fluent_api_extension | |
 | Streams | Window DSL機能 | ❌ 未実装 | window_dsl_feature | TumblingWindow等 |
 | Streams | 購読モードの固定化制御 | ⏳ 部分実装 | subscription_mode_fixed | UseManualCommitの実行時切替未実装 |
 | Tables | LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ✅ 実装済 | ksql_offset_aggregates | ProjectionBuilderで変換完了 |
 | Tables | 複数ウィンドウ定義とアクセス | ❌ 未実装 | multi_window_access | |
-| Tables | HasTopic()メソッド | ❌ 未実装 | has_topic_api_extension | |
+| Tables | HasTopic()メソッド | ✅ 実装済 | has_topic_api_extension | EntityModelBuilder & tests |
 | Tables | WindowStart / WindowEndプロパティ | ❌ 未実装 | window_start_end_support | |
 | Query & Subscription | 手動コミット購読処理の型分岐 | ⏳ 不完全 | manual_commit_extension | Ack操作・型分岐不足 |
-| Query & Subscription | 購読処理の完全実装 | ❌ 未実装 | manual_commit_extension | CommitAsync等未実装 |
+| Query & Subscription | 購読処理の完全実装 | ⏳ 部分実装 | manual_commit_extension | Commit/NegativeAck methods implemented; type branch pending
 | Query & Subscription | yield型ForEachAsyncでのtry-catch | ❌ 未実装 | foreach_trycatch_support | |
 | Special Types | char型警告 | ❌ 未実装 | special_type_handling | 警告処理なし |
 | Special Types | short型自動int変換 | ❌ 未実装 | special_type_handling | 変換処理不明確 |


### PR DESCRIPTION
## Summary
- update task coverage table to mark topic configuration API and HasTopic API as implemented
- update implementation status doc accordingly

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e10d9513483279e738f163c5ba58f