### PR TITLE
Add partitioner fluent API option

### DIFF
--- a/src/Core/Abstractions/TopicAttribute.cs
+++ b/src/Core/Abstractions/TopicAttribute.cs
@@ -17,6 +17,11 @@ public class TopicAttribute : Attribute
 
     public bool DeadLetterQueue { get; set; } = false;
 
+    /// <summary>
+    /// カスタムパーティショニング戦略名
+    /// </summary>
+    public string? Partitioner { get; set; }
+
     public string? Description { get; set; }
 
     public int? MaxMessageBytes { get; set; }

--- a/src/Core/Modeling/EntityBuilderTopicExtensions.cs
+++ b/src/Core/Modeling/EntityBuilderTopicExtensions.cs
@@ -28,5 +28,12 @@ public static class EntityBuilderTopicExtensions
             throw new ArgumentException("Invalid builder type", nameof(builder));
         return concrete.WithReplicationFactor(replicationFactor);
     }
+
+    public static IEntityBuilder<T> WithPartitioner<T>(this IEntityBuilder<T> builder, string partitioner) where T : class
+    {
+        if (builder is not EntityModelBuilder<T> concrete)
+            throw new ArgumentException("Invalid builder type", nameof(builder));
+        return concrete.WithPartitioner(partitioner);
+    }
 }
 

--- a/src/Core/Modeling/EntityModelBuilder.cs
+++ b/src/Core/Modeling/EntityModelBuilder.cs
@@ -70,6 +70,16 @@ public class EntityModelBuilder<T> : IEntityBuilder<T> where T : class
         return this;
     }
 
+    public EntityModelBuilder<T> WithPartitioner(string partitioner)
+    {
+        if (string.IsNullOrWhiteSpace(partitioner))
+            throw new ArgumentException("Partitioner cannot be null or empty", nameof(partitioner));
+
+        var attr = EnsureTopicAttribute();
+        attr.Partitioner = partitioner;
+        return this;
+    }
+
     public EntityModel GetModel()
     {
         return _entityModel;

--- a/tasks/topic_fluent_api_extension/README.md
+++ b/tasks/topic_fluent_api_extension/README.md
@@ -1,1 +1,5 @@
 # topic_fluent_api_extension
+
+Fluent API to configure Kafka topic settings on `ModelBuilder.Entity<T>()`.
+This includes topic name, partitions, replication factor and now a custom
+partitioner strategy.

--- a/tests/Core/AttributeTests.cs
+++ b/tests/Core/AttributeTests.cs
@@ -72,4 +72,11 @@ public class TopicAttributeTests
         Assert.Contains("desc", str);
         Assert.Contains("topic1", str);
     }
+
+    [Fact]
+    public void Partitioner_Property_RoundTrips()
+    {
+        var attr = new TopicAttribute("topic1") { Partitioner = "p" };
+        Assert.Equal("p", attr.Partitioner);
+    }
 }

--- a/tests/ModelBuilderTests/TopicFluentApiTests.cs
+++ b/tests/ModelBuilderTests/TopicFluentApiTests.cs
@@ -19,12 +19,14 @@ public class TopicFluentApiTests
         builder.Entity<Order>()
             .HasTopic("orders")
             .WithPartitions(3)
-            .WithReplicationFactor(2);
+            .WithReplicationFactor(2)
+            .WithPartitioner("custom");
 
         var model = builder.GetEntityModel<Order>();
         Assert.NotNull(model.TopicAttribute);
         Assert.Equal("orders", model.TopicAttribute!.TopicName);
         Assert.Equal(3, model.TopicAttribute.PartitionCount);
         Assert.Equal(2, model.TopicAttribute.ReplicationFactor);
+        Assert.Equal("custom", model.TopicAttribute.Partitioner);
     }
 }


### PR DESCRIPTION
## Summary
- extend TopicAttribute with `Partitioner`
- expose `WithPartitioner` on EntityModelBuilder and extensions
- test partitioner configuration
- document the feature in task README

## Testing
- `dotnet test --no-build --verbosity minimal tests/ModelBuilderTests/ModelBuilderTests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e28ed2b488327861c322d32e49a4c