### PR TITLE
Add topic ISR configuration

### DIFF
--- a/src/Core/Abstractions/TopicAttribute.cs
+++ b/src/Core/Abstractions/TopicAttribute.cs
@@ -11,6 +11,11 @@ public class TopicAttribute : Attribute
 
     public int ReplicationFactor { get; set; } = 1;
 
+    /// <summary>
+    /// ISR最小数。Kafkaのトピック可用性を保つには必須
+    /// </summary>
+    public int? MinInSyncReplicas { get; set; }
+
     public long RetentionMs { get; set; } = 604800000; // 7 days
 
     public bool Compaction { get; set; } = false;
@@ -54,6 +59,9 @@ public class TopicAttribute : Attribute
 
         if (SegmentBytes.HasValue)
             config["segment.bytes"] = (int)SegmentBytes.Value;
+
+        if (MinInSyncReplicas.HasValue)
+            config["min.insync.replicas"] = MinInSyncReplicas.Value;
 
         return config;
     }

--- a/src/Core/Modeling/EntityModelBuilder.cs
+++ b/src/Core/Modeling/EntityModelBuilder.cs
@@ -43,7 +43,8 @@ public class EntityModelBuilder<T> : IEntityBuilder<T> where T : class
             DeadLetterQueue = current.DeadLetterQueue,
             Description = current.Description,
             MaxMessageBytes = current.MaxMessageBytes,
-            SegmentBytes = current.SegmentBytes
+            SegmentBytes = current.SegmentBytes,
+            MinInSyncReplicas = current.MinInSyncReplicas
         };
 
         _entityModel.TopicAttribute = newAttr;
@@ -67,6 +68,16 @@ public class EntityModelBuilder<T> : IEntityBuilder<T> where T : class
 
         var attr = EnsureTopicAttribute();
         attr.ReplicationFactor = replicationFactor;
+        return this;
+    }
+
+    public EntityModelBuilder<T> WithMinInSyncReplicas(int minInSyncReplicas)
+    {
+        if (minInSyncReplicas <= 0)
+            throw new ArgumentException("MinInSyncReplicas must be greater than 0", nameof(minInSyncReplicas));
+
+        var attr = EnsureTopicAttribute();
+        attr.MinInSyncReplicas = minInSyncReplicas;
         return this;
     }
 

--- a/src/Messaging/Exceptions/KafkaTopicConflictException.cs
+++ b/src/Messaging/Exceptions/KafkaTopicConflictException.cs
@@ -1,0 +1,12 @@
+using Kafka.Ksql.Linq.Core.Exceptions;
+
+namespace Kafka.Ksql.Linq.Messaging.Exceptions;
+
+/// <summary>
+/// Thrown when managed topic settings conflict with existing Kafka configuration.
+/// </summary>
+public class KafkaTopicConflictException : KafkaMessageBusException
+{
+    public KafkaTopicConflictException(string message) : base(message) { }
+    public KafkaTopicConflictException(string message, System.Exception innerException) : base(message, innerException) { }
+}

--- a/tasks/topic_fluent_api_extension/README.md
+++ b/tasks/topic_fluent_api_extension/README.md
@@ -1,5 +1,5 @@
 # topic_fluent_api_extension
 
 Fluent API to configure Kafka topic settings on `ModelBuilder.Entity<T>()`.
-This includes topic name, partitions, replication factor and now a custom
-partitioner strategy.
+Supported options include topic name, partitions, replication factor, custom
+partitioner strategy and **MinInSyncReplicas** for ISR control.

--- a/tests/Kafka.Ksql.Linq.Tests.csproj
+++ b/tests/Kafka.Ksql.Linq.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <ProjectReference Include="../src/Kafka.Ksql.Linq.csproj" />
+    <Compile Include="../samples/topic_fluent_api_extension/ManagedTopicExtensions.cs" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/ModelBuilderTests/TopicIsrSettingTests.cs
+++ b/tests/ModelBuilderTests/TopicIsrSettingTests.cs
@@ -1,0 +1,55 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Samples.TopicFluentApiExtension;
+using Kafka.Ksql.Linq.Messaging.Exceptions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.ModelBuilderTests;
+
+public class TopicIsrSettingTests
+{
+    private class Order
+    {
+        [Key]
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void FluentApi_StoresMinInSyncReplicas()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<Order>()
+            .HasTopic("orders")
+            .WithReplicationFactor(3)
+            .WithMinInSyncReplicas(2);
+
+        var model = builder.GetEntityModel<Order>();
+        Assert.NotNull(model.TopicAttribute);
+        Assert.Equal(2, model.TopicAttribute!.MinInSyncReplicas);
+    }
+
+    [Fact]
+    public void MinInSyncReplicas_DefaultsToNull()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<Order>().HasTopic("orders");
+        var model = builder.GetEntityModel<Order>();
+        Assert.Null(model.TopicAttribute!.MinInSyncReplicas);
+    }
+
+    [Fact]
+    public void IsManaged_ThrowsWhenSettingsConflict()
+    {
+        var builder = new ModelBuilder();
+        var entity = builder.Entity<Order>()
+            .HasTopic("orders")
+            .WithReplicationFactor(3)
+            .WithMinInSyncReplicas(2);
+
+        ManagedTopicExtensions.RegisterExistingTopic("orders", new TopicAttribute("orders") { ReplicationFactor = 3, MinInSyncReplicas = 1 });
+
+        Assert.Throws<KafkaTopicConflictException>(() => entity.IsManaged(true));
+
+        ManagedTopicExtensions.ClearRegisteredTopics();
+    }
+}


### PR DESCRIPTION
## Summary
- add `MinInSyncReplicas` property to `TopicAttribute`
- expose `WithMinInSyncReplicas` fluent API on `EntityModelBuilder`
- validate topic conflicts in sample `IsManaged` extension
- create `KafkaTopicConflictException`
- include ISR tests and wire up sample extension for tests
- document MinInSyncReplicas in task README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f34aa248327bfe43547ec10e232