### PR TITLE
Fix unit test warnings

### DIFF
--- a/tests/Application/EventSetWithServicesSendTests.cs
+++ b/tests/Application/EventSetWithServicesSendTests.cs
@@ -8,6 +8,8 @@ using Kafka.Ksql.Linq.Application;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System;
+
+#nullable enable
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Application/KsqlContextConversionTests.cs
+++ b/tests/Application/KsqlContextConversionTests.cs
@@ -21,7 +21,7 @@ public class KsqlContextConversionTests
     {
         public TestContext() : base() { }
         protected override bool SkipSchemaRegistration => true;
-        public new IReadOnlyDictionary<Type, AvroEntityConfiguration> Convert(Dictionary<Type, EntityModel> models)
+        public IReadOnlyDictionary<Type, AvroEntityConfiguration> Convert(Dictionary<Type, EntityModel> models)
             => base.ConvertToAvroConfigurations(models);
     }
 

--- a/tests/Application/KsqlContextTests.cs
+++ b/tests/Application/KsqlContextTests.cs
@@ -17,11 +17,11 @@ public class KsqlContextTests
 
         protected override bool SkipSchemaRegistration => true;
 
-        public new IEntitySet<T> CallCreateEntitySet<T>(EntityModel model) where T : class
+        public IEntitySet<T> CallCreateEntitySet<T>(EntityModel model) where T : class
             => base.CreateEntitySet<T>(model);
 
-        public new KafkaProducerManager CallGetProducerManager() => base.GetProducerManager();
-        public new KafkaConsumerManager CallGetConsumerManager() => base.GetConsumerManager();
+        public KafkaProducerManager CallGetProducerManager() => base.GetProducerManager();
+        public KafkaConsumerManager CallGetConsumerManager() => base.GetConsumerManager();
     }
 
     [Fact]

--- a/tests/Core/CoreExtensionsMoreTests.cs
+++ b/tests/Core/CoreExtensionsMoreTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Linq;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Core;
 
 public class CoreExtensionsMoreTests

--- a/tests/Core/LoggerFactoryExtensionsTests.cs
+++ b/tests/Core/LoggerFactoryExtensionsTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.IO;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Core;
 
 public class LoggerFactoryExtensionsTests

--- a/tests/Core/ModelBuilderTests.cs
+++ b/tests/Core/ModelBuilderTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Core;
 
 public class ModelBuilderTests

--- a/tests/Messaging/KafkaConsumerManagerTests.cs
+++ b/tests/Messaging/KafkaConsumerManagerTests.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Options;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Messaging;
 
 public class KafkaConsumerManagerTests
@@ -73,7 +75,7 @@ public class KafkaConsumerManagerTests
     public void GetOrCreateSerializationManager_CachesInstance()
     {
         var options = new KsqlDslOptions();
-        var manager = (KafkaConsumerManager)FormatterServices.GetUninitializedObject(typeof(KafkaConsumerManager));
+        var manager = (KafkaConsumerManager)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(KafkaConsumerManager));
         typeof(KafkaConsumerManager).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, options);
         typeof(KafkaConsumerManager).GetField("_loggerFactory", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new NullLoggerFactory());
         typeof(KafkaConsumerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
@@ -88,7 +90,7 @@ public class KafkaConsumerManagerTests
     [Fact]
     public void GetEntityModel_ReturnsModelWithAttributes()
     {
-        var manager = (KafkaConsumerManager)FormatterServices.GetUninitializedObject(typeof(KafkaConsumerManager));
+        var manager = (KafkaConsumerManager)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(KafkaConsumerManager));
         typeof(KafkaConsumerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
         var model = InvokePrivate<Kafka.Ksql.Linq.Core.Abstractions.EntityModel>(manager, "GetEntityModel", Type.EmptyTypes, new[] { typeof(SampleEntity) });
         Assert.Equal(typeof(SampleEntity), model.EntityType);

--- a/tests/Messaging/KafkaProducerManagerExtraTests.cs
+++ b/tests/Messaging/KafkaProducerManagerExtraTests.cs
@@ -74,7 +74,7 @@ public class KafkaProducerManagerExtraTests
         Assert.Equal("key", config.SslKeyLocation);
         Assert.Equal("kp", config.SslKeyPassword);
         var entries = (System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>)config;
-        Assert.True(System.Linq.Enumerable.Any(entries, kv => kv.Key == "partitioner.class" && kv.Value == "m"));
+        Assert.Contains(entries, kv => kv.Key == "partitioner.class" && kv.Value == "m");
     }
 
     [Fact]

--- a/tests/Messaging/KafkaProducerManagerTests.cs
+++ b/tests/Messaging/KafkaProducerManagerTests.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Options;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Messaging;
 
 public class KafkaProducerManagerTests
@@ -65,7 +67,7 @@ public class KafkaProducerManagerTests
     public void GetOrCreateSerializationManager_CachesInstance()
     {
         var options = new KsqlDslOptions();
-        var manager = (KafkaProducerManager)FormatterServices.GetUninitializedObject(typeof(KafkaProducerManager));
+        var manager = (KafkaProducerManager)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(KafkaProducerManager));
         typeof(KafkaProducerManager).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, options);
         typeof(KafkaProducerManager).GetField("_loggerFactory", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new NullLoggerFactory());
         typeof(KafkaProducerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
@@ -81,7 +83,7 @@ public class KafkaProducerManagerTests
     [Fact]
     public void GetEntityModel_ReturnsModelWithAttributes()
     {
-        var manager = (KafkaProducerManager)FormatterServices.GetUninitializedObject(typeof(KafkaProducerManager));
+        var manager = (KafkaProducerManager)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(KafkaProducerManager));
         typeof(KafkaProducerManager).GetField("_serializationManagers", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(manager, new ConcurrentDictionary<Type, object>());
         var model = InvokePrivate<Kafka.Ksql.Linq.Core.Abstractions.EntityModel>(manager, "GetEntityModel", Type.EmptyTypes, new[] { typeof(SampleEntity) });
         Assert.Equal(typeof(SampleEntity), model.EntityType);

--- a/tests/PrivateAccessor.cs
+++ b/tests/PrivateAccessor.cs
@@ -7,7 +7,7 @@ namespace Kafka.Ksql.Linq.Tests;
 
 internal static class PrivateAccessor
 {
-    internal static object InvokePrivate(
+    internal static object? InvokePrivate(
         object target,
         string name,
         Type[] parameterTypes,

--- a/tests/PrivateAccessor.cs
+++ b/tests/PrivateAccessor.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Reflection;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 internal static class PrivateAccessor

--- a/tests/Query/Builders/BigBangScenarioTests.cs
+++ b/tests/Query/Builders/BigBangScenarioTests.cs
@@ -5,6 +5,8 @@ using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Query.Builders;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
 public record OrderCustomerInfo(DateTime OrderDate, decimal TotalAmount, string? Region);

--- a/tests/Query/Builders/JoinBuilderTests.cs
+++ b/tests/Query/Builders/JoinBuilderTests.cs
@@ -7,6 +7,8 @@ using Kafka.Ksql.Linq.Query.Builders;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
 public class JoinBuilderTests

--- a/tests/Query/Builders/ProjectionBuilderTests.cs
+++ b/tests/Query/Builders/ProjectionBuilderTests.cs
@@ -5,6 +5,8 @@ using Kafka.Ksql.Linq.Query.Builders;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
 public class ProjectionBuilderTests

--- a/tests/Query/Pipeline/QueryExecutionPipelineTests.cs
+++ b/tests/Query/Pipeline/QueryExecutionPipelineTests.cs
@@ -119,7 +119,7 @@ public class QueryExecutionPipelineTests
         var pipeline = CreatePipeline();
         var result = await pipeline.ExecuteQueryAsync<TestEntity>("Base", expr, QueryExecutionMode.PullQuery);
         Assert.True(result.Success);
-        Assert.NotNull(result.ExecutedAt);
+        Assert.NotEqual(default, result.ExecutedAt);
         Assert.NotNull(result.Data);
     }
 }

--- a/tests/Query/TestEntities.cs
+++ b/tests/Query/TestEntities.cs
@@ -1,5 +1,7 @@
 using System;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests;
 
 public class TestEntity

--- a/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
+++ b/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
@@ -9,6 +9,8 @@ using Kafka.Ksql.Linq.Serialization.Avro.Management;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Serialization;
 
 public class AvroSchemaBuilderDetailedTests

--- a/tests/Serialization/FakeSchemaRegistryClient.cs
+++ b/tests/Serialization/FakeSchemaRegistryClient.cs
@@ -6,6 +6,8 @@ using Confluent.SchemaRegistry;
 
 namespace Kafka.Ksql.Linq.Tests.Serialization;
 
+#nullable enable
+
 internal class FakeSchemaRegistryClient : DispatchProxy
 {
     public List<string> RegisterSubjects { get; } = new();

--- a/tests/Serialization/ResilientAvroSerializerManagerTests.cs
+++ b/tests/Serialization/ResilientAvroSerializerManagerTests.cs
@@ -16,7 +16,7 @@ public class ResilientAvroSerializerManagerTests
 
     private static ResilientAvroSerializerManager CreateUninitialized()
     {
-        var mgr = (ResilientAvroSerializerManager)FormatterServices.GetUninitializedObject(typeof(ResilientAvroSerializerManager));
+        var mgr = (ResilientAvroSerializerManager)System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof(ResilientAvroSerializerManager));
         typeof(ResilientAvroSerializerManager).GetField("_logger", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(mgr, NullLogger<ResilientAvroSerializerManager>.Instance);
         return mgr;

--- a/tests/Serialization/SchemaRegistryClientWrapperTests.cs
+++ b/tests/Serialization/SchemaRegistryClientWrapperTests.cs
@@ -6,6 +6,8 @@ using Confluent.SchemaRegistry;
 using Kafka.Ksql.Linq.Serialization.Avro.Core;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Serialization;
 
 public class SchemaRegistryClientWrapperTests

--- a/tests/Serialization/UnifiedSchemaGeneratorTests.cs
+++ b/tests/Serialization/UnifiedSchemaGeneratorTests.cs
@@ -8,6 +8,8 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Serialization.Avro.Core;
 using Kafka.Ksql.Linq.Serialization.Abstractions;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
+
+#nullable enable
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Serialization;

--- a/tests/StateStore/EventSetWithStateStoreKeyTests.cs
+++ b/tests/StateStore/EventSetWithStateStoreKeyTests.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.StateStore;
 
 public class EventSetWithStateStoreKeyTests


### PR DESCRIPTION
## Summary
- enable nullable annotations for test sources
- replace obsolete FormatterServices with RuntimeHelpers
- clean up `new` keyword usage
- use `Assert.Contains` instead of `Assert.True`
- avoid asserting nullability on value types

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e522dc478832795e2eff82a4cff48