### PR TITLE
Implement window start/end query support

### DIFF
--- a/src/Extensions/WindowInfoExtensions.cs
+++ b/src/Extensions/WindowInfoExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Kafka.Ksql.Linq
+{
+    /// <summary>
+    /// Provides access to WINDOWSTART and WINDOWEND metadata within LINQ expressions.
+    /// These methods are intended only for expression translation and should not
+    /// be executed at runtime.
+    /// </summary>
+    public static class WindowInfoExtensions
+    {
+        public static DateTime WindowStart<TSource, TKey>(this IGrouping<TKey, TSource> source)
+        {
+            throw new NotSupportedException("WindowStart is for expression translation only.");
+        }
+
+        public static DateTime WindowEnd<TSource, TKey>(this IGrouping<TKey, TSource> source)
+        {
+            throw new NotSupportedException("WindowEnd is for expression translation only.");
+        }
+    }
+}

--- a/src/Query/Builders/ProjectionBuilder.cs
+++ b/src/Query/Builders/ProjectionBuilder.cs
@@ -117,6 +117,12 @@ internal class ProjectionBuilder : IKsqlBuilder
             // Handle common KSQL functions that might appear in projections
             switch (methodName)
             {
+                case "WINDOWSTART":
+                    _sb.Append("WINDOWSTART");
+                    break;
+                case "WINDOWEND":
+                    _sb.Append("WINDOWEND");
+                    break;
                 case "TOSTRING":
                     _sb.Append("CAST(");
                     Visit(node.Object ?? node.Arguments[0]);

--- a/src/Query/Pipeline/WindowDDLExtensions.cs
+++ b/src/Query/Pipeline/WindowDDLExtensions.cs
@@ -188,6 +188,8 @@ internal class WindowSelectExpressionVisitor : ExpressionVisitor
 
         return methodName switch
         {
+            "WindowStart" => "WINDOWSTART",
+            "WindowEnd" => "WINDOWEND",
             "Sum" => ExtractAggregationColumn("SUM", methodCall),
             "Count" => "COUNT(*)",
             "Max" => ExtractAggregationColumn("MAX", methodCall),

--- a/tasks/implement_diff_completion/coverage.md
+++ b/tasks/implement_diff_completion/coverage.md
@@ -12,7 +12,7 @@
 | Tables | LATEST_BY_OFFSET / EARLIEST_BY_OFFSET | ✅ 実装済 | ksql_offset_aggregates | ProjectionBuilderで変換完了 |
 | Tables | 複数ウィンドウ定義とアクセス | ✅ 実装済 | multi_window_access | |
 | Tables | HasTopic()メソッド | ✅ 実装済 | has_topic_api_extension | EntityModelBuilder & tests |
-| Tables | WindowStart / WindowEndプロパティ | ❌ 未実装 | window_start_end_support | |
+| Tables | WindowStart / WindowEndプロパティ | ✅ 実装済 | window_start_end_support | ProjectionBuilder, WindowDDLExtensions |
 | Query & Subscription | 手動コミット購読処理の型分岐 | ⏳ 不完全 | manual_commit_extension | Ack操作・型分岐不足 |
 | Query & Subscription | 購読処理の完全実装 | ⏳ 部分実装 | manual_commit_extension | Commit/NegativeAck methods implemented; type branch pending
 | Query & Subscription | yield型ForEachAsyncでのtry-catch | ❌ 未実装 | foreach_trycatch_support | |

--- a/tests/KsqlDslTests/Aggregate/WindowStartEndTests.cs
+++ b/tests/KsqlDslTests/Aggregate/WindowStartEndTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Query.Pipeline;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.KsqlDslTests.Aggregate;
+
+public class WindowStartEndTests
+{
+    private class FakeExecutor : KsqlDbExecutor
+    {
+        public FakeExecutor() : base(new NullLoggerFactory()) { }
+        public override void ExecuteDDL(string ddlQuery) { }
+        public override System.Threading.Tasks.Task ExecuteDDLAsync(string ddlQuery) => System.Threading.Tasks.Task.CompletedTask;
+        public override System.Threading.Tasks.Task<List<T>> ExecutePullQueryAsync<T>(string query) where T : class => System.Threading.Tasks.Task.FromResult(new List<T>());
+        public override System.Threading.Tasks.Task<List<T>> ExecutePushQueryAsync<T>(string query) where T : class => System.Threading.Tasks.Task.FromResult(new List<T>());
+        public override System.Threading.Tasks.Task StopAllQueriesAsync() => System.Threading.Tasks.Task.CompletedTask;
+        public override void Dispose() { }
+    }
+
+    private static QueryExecutionPipeline CreatePipeline()
+    {
+        var executor = new FakeExecutor();
+        var manager = new DerivedObjectManager(executor, new DDLQueryGenerator(new NullLoggerFactory()), new StreamTableAnalyzer(new NullLoggerFactory()), new NullLoggerFactory());
+        var ddl = new DDLQueryGenerator(new NullLoggerFactory());
+        var dml = new DMLQueryGenerator(new NullLoggerFactory());
+        var analyzer = new StreamTableAnalyzer(new NullLoggerFactory());
+        return new QueryExecutionPipeline(manager, ddl, dml, executor, analyzer, new NullLoggerFactory());
+    }
+
+    [Fact]
+    public void Select_WindowStartEnd_GeneratesFunctions()
+    {
+        IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();
+        var expr = src.GroupBy(e => e.Type)
+                       .Select(g => new { g.Key, Start = g.WindowStart(), End = g.WindowEnd() });
+
+        var pipeline = CreatePipeline();
+        var ksql = pipeline.GenerateKsqlQuery("Trades", expr.Expression, false);
+
+        Assert.Contains("WINDOWSTART", ksql);
+        Assert.Contains("WINDOWEND", ksql);
+    }
+}


### PR DESCRIPTION
## Summary
- expose WINDOWSTART/WINDOWEND through new extension methods
- translate WindowStart/WindowEnd method calls in ProjectionBuilder and WindowDDLExtensions
- add regression test ensuring KSQL includes WINDOWSTART/WINDOWEND
- mark WindowStartEnd feature as implemented in coverage progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e55a218008327919810f266e85891