### PR TITLE
Implement char/short handling

### DIFF
--- a/checklist/etc.txt
+++ b/checklist/etc.txt
@@ -85,5 +85,9 @@ JSON比較時は空白・改行・大文字小文字を柔軟に許容し、必�
 13. 「テストの期待値（Expected）がダミーデータ/セットアップ値と一致しているか」
 14. 「バージョンや履歴等、リスト要素数も期待値どおりか」
 
+15. ビルド成果物
+ Kafka.Ksql.Linq -> /home/runner/work/jinto/jinto/src/bin/Release/net8.0/Kafka.Ksql.Linq.dll
+ Kafka.Ksql.Linq.Importer -> /home/runner/work/jinto/jinto/Kafka.Ksql.Linq.Importer/bin/Release/net8.0/Kafka.Ksql.Linq.Importer.dll
+
 
 本ガイドラインは、今後も現場運用・AI反省のたびに随時アップデートせよ！

--- a/docs/implement_status.md
+++ b/docs/implement_status.md
@@ -9,4 +9,4 @@
 | DLQ設定（ModelBuilder） | ⏳ 部分実装 | dlq_configuration_support | `TopicAttribute` 定義はある |
 | HasTopic API | ✅ 実装済 | has_topic_api_extension | EntityBuilderTopicExtensions|
 | ManualCommit切替 | ✅ 実装済 | manual_commit_extension | ForEachAsync型分岐対応 |
-| char/shortサポート | ❌ 未実装 | special_type_handling | 警告・自動変換未実装 |
+| char/shortサポート | ✅ 実装済 | special_type_handling | 警告出力とint変換対応 |

--- a/src/Core/Modeling/ModelBuilder.cs
+++ b/src/Core/Modeling/ModelBuilder.cs
@@ -170,7 +170,13 @@ internal class ModelBuilder : IModelBuilder
         // プロパティの検証
         foreach (var property in model.AllProperties)
         {
-            if (!IsValidPropertyType(property.PropertyType))
+            var underlying = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+            if (underlying == typeof(char))
+            {
+                result.Warnings.Add($"Property {property.Name} is of type char which may not map cleanly to KSQL. Consider using string instead.");
+            }
+            else if (!IsValidPropertyType(property.PropertyType))
             {
                 result.Warnings.Add($"Property {property.Name} has potentially unsupported type {property.PropertyType.Name}");
             }

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -136,8 +136,10 @@ internal class DDLQueryGenerator : IDDLQueryGenerator
         return underlyingType switch
         {
             Type t when t == typeof(int) => "INTEGER",
+            Type t when t == typeof(short) => "INTEGER",
             Type t when t == typeof(long) => "BIGINT",
             Type t when t == typeof(double) => "DOUBLE",
+            Type t when t == typeof(char) => "VARCHAR",
             Type t when t == typeof(decimal) => "DECIMAL",
             Type t when t == typeof(string) => "VARCHAR",
             Type t when t == typeof(bool) => "BOOLEAN",

--- a/src/Query/Pipeline/WindowDDLExtensions.cs
+++ b/src/Query/Pipeline/WindowDDLExtensions.cs
@@ -136,11 +136,13 @@ internal static class WindowDDLExtensions
         return type switch
         {
             Type t when t == typeof(int) => "int",
+            Type t when t == typeof(short) => "int",
             Type t when t == typeof(long) => "long",
             Type t when t == typeof(double) => "double",
             Type t when t == typeof(float) => "float",
             Type t when t == typeof(bool) => "boolean",
             Type t when t == typeof(string) => "string",
+            Type t when t == typeof(char) => "string",
             Type t when t == typeof(DateTime) => "long",
             Type t when t == typeof(DateTimeOffset) => "long",
             Type t when t == typeof(decimal) => "bytes",

--- a/tasks/implement_diff_completion/coverage.md
+++ b/tasks/implement_diff_completion/coverage.md
@@ -16,8 +16,8 @@
 | Query & Subscription | 手動コミット購読処理の型分岐 | ✅ 実装済 | manual_commit_extension | ForEachAsyncでIManualCommitMessageを返す |
 | Query & Subscription | 購読処理の完全実装 | ✅ 実装済 | manual_commit_extension | Commit/NegativeAck呼び出し対応 |
 | Query & Subscription | yield型ForEachAsyncでのtry-catch | ✅ 実装済 | foreach_trycatch_support | |
-| Special Types | char型警告 | ❌ 未実装 | special_type_handling | 警告処理なし |
-| Special Types | short型自動int変換 | ❌ 未実装 | special_type_handling | 変換処理不明確 |
+| Special Types | char型警告 | ✅ 実装済 | special_type_handling | ModelBuilderで警告 |
+| Special Types | short型自動int変換 | ✅ 実装済 | special_type_handling | DDL/Avro変換対応 |
 | Error Handling | チェーン可能なエラー処理DSL | ⏳ 部分実装 | chainable_error_dsl | OnError→Map→Retryの連鎖未完成 |
 | Error Handling | デシリアライズエラーポリシー | ❌ 未実装 | deserialization_error_policy | |
 | Error Handling | ModelBuilderでのDLQ設定 | ⏳ 部分実装 | dlq_configuration_support | TopicAttributeには存在 |

--- a/tasks/special_type_handling/README.md
+++ b/tasks/special_type_handling/README.md
@@ -1,1 +1,2 @@
 # special_type_handling
+Char 型利用時の警告出力と short 型の自動 int 変換を行う対応。

--- a/tasks/special_type_handling/worklog.md
+++ b/tasks/special_type_handling/worklog.md
@@ -1,0 +1,4 @@
+# special_type_handling
+- Added warning output for char properties during model validation.
+- Added short->int conversion support in DDL and Avro mappings.
+- Updated coverage documentation to mark this task as completed.

--- a/tests/ModelBuilderTests/SpecialTypeHandlingTests.cs
+++ b/tests/ModelBuilderTests/SpecialTypeHandlingTests.cs
@@ -1,5 +1,7 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.ModelBuilderTests;
@@ -23,7 +25,7 @@ public class SpecialTypeHandlingTests
     [Fact]
     public void CharProperty_ProducesWarning()
     {
-        var builder = new ModelBuilder(ValidationMode.Loose);
+        var builder = new ModelBuilder(ValidationMode.Relaxed);
         builder.Entity<CharEntity>();
 
         var model = builder.GetEntityModel<CharEntity>()!;
@@ -33,10 +35,8 @@ public class SpecialTypeHandlingTests
     [Fact]
     public void ShortProperty_MappedAsInteger()
     {
-        var generator = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator(new Kafka.Ksql.Linq.Query.Pipeline.SelectBuilder(), new Kafka.Ksql.Linq.Query.Pipeline.WhereBuilder(), new Kafka.Ksql.Linq.Query.Pipeline.GroupByBuilder());
-        var type = typeof(short);
-        var method = typeof(Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator).GetMethod("MapToKsqlType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        var result = (string)method.Invoke(generator, new object[] { type })!;
+        var generator = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator(new NullLoggerFactory());
+        var result = PrivateAccessor.InvokePrivate<string>(generator, "MapToKsqlType", new[] { typeof(Type) }, args: new object?[] { typeof(short) });
         Assert.Equal("INTEGER", result);
     }
 }

--- a/tests/ModelBuilderTests/SpecialTypeHandlingTests.cs
+++ b/tests/ModelBuilderTests/SpecialTypeHandlingTests.cs
@@ -1,0 +1,42 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.ModelBuilderTests;
+
+public class SpecialTypeHandlingTests
+{
+    private class CharEntity
+    {
+        [Key]
+        public int Id { get; set; }
+        public char Code { get; set; }
+    }
+
+    private class ShortEntity
+    {
+        [Key]
+        public int Id { get; set; }
+        public short Quantity { get; set; }
+    }
+
+    [Fact]
+    public void CharProperty_ProducesWarning()
+    {
+        var builder = new ModelBuilder(ValidationMode.Loose);
+        builder.Entity<CharEntity>();
+
+        var model = builder.GetEntityModel<CharEntity>()!;
+        Assert.Contains(model.ValidationResult!.Warnings, w => w.Contains("char"));
+    }
+
+    [Fact]
+    public void ShortProperty_MappedAsInteger()
+    {
+        var generator = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator(new Kafka.Ksql.Linq.Query.Pipeline.SelectBuilder(), new Kafka.Ksql.Linq.Query.Pipeline.WhereBuilder(), new Kafka.Ksql.Linq.Query.Pipeline.GroupByBuilder());
+        var type = typeof(short);
+        var method = typeof(Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator).GetMethod("MapToKsqlType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var result = (string)method.Invoke(generator, new object[] { type })!;
+        Assert.Equal("INTEGER", result);
+    }
+}

--- a/tests/ModelBuilderTests/SpecialTypeHandlingTests.cs
+++ b/tests/ModelBuilderTests/SpecialTypeHandlingTests.cs
@@ -1,8 +1,11 @@
+using System;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+
+#nullable enable
 
 namespace Kafka.Ksql.Linq.Tests.ModelBuilderTests;
 


### PR DESCRIPTION
## Summary
- warn on `char` properties during model validation
- map `short` to INTEGER in DDL and Avro helpers
- update coverage docs and task records
- add unit tests for special type handling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e62206d3c83279e0c48487a1887da