### PR TITLE
Implement deserialization DLQ handling

### DIFF
--- a/src/Configuration/KsqlDslOptions.cs
+++ b/src/Configuration/KsqlDslOptions.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
 using System.Collections.Generic;
 
 namespace Kafka.Ksql.Linq.Configuration;
@@ -29,4 +30,9 @@ public class KsqlDslOptions
     public string DlqTopicName { get; set; } = "dead.letter.queue";
 
     public DlqTopicConfiguration DlqConfiguration { get; init; } = new();
+
+    /// <summary>
+    /// デシリアライズ失敗時のポリシー
+    /// </summary>
+    public DeserializationErrorPolicy DeserializationErrorPolicy { get; set; } = DeserializationErrorPolicy.Skip;
 }

--- a/src/Core/Abstractions/DeserializationErrorPolicy.cs
+++ b/src/Core/Abstractions/DeserializationErrorPolicy.cs
@@ -1,0 +1,8 @@
+namespace Kafka.Ksql.Linq.Core.Abstractions;
+
+public enum DeserializationErrorPolicy
+{
+    Skip,
+    Retry,
+    DLQ
+}

--- a/src/Core/Abstractions/EntityModel.cs
+++ b/src/Core/Abstractions/EntityModel.cs
@@ -78,4 +78,14 @@ public class EntityModel
     /// 手動コミットモード使用フラグ
     /// </summary>
     public bool UseManualCommit { get; set; } = false;
+
+    /// <summary>
+    /// 処理エラー発生時のアクション
+    /// </summary>
+    public ErrorAction ErrorAction { get; set; } = ErrorAction.Skip;
+
+    /// <summary>
+    /// デシリアライズ失敗時のポリシー
+    /// </summary>
+    public DeserializationErrorPolicy DeserializationErrorPolicy { get; set; } = DeserializationErrorPolicy.Skip;
 }

--- a/src/Core/Modeling/EntityModelBuilder.cs
+++ b/src/Core/Modeling/EntityModelBuilder.cs
@@ -28,6 +28,18 @@ public class EntityModelBuilder<T> : IEntityBuilder<T> where T : class
         return this;
     }
 
+    public EntityModelBuilder<T> OnError(ErrorAction action)
+    {
+        _entityModel.ErrorAction = action;
+        return this;
+    }
+
+    public EntityModelBuilder<T> OnDeserializationError(DeserializationErrorPolicy policy)
+    {
+        _entityModel.DeserializationErrorPolicy = policy;
+        return this;
+    }
+
     public EntityModelBuilder<T> HasTopic(string topicName)
     {
         if (string.IsNullOrWhiteSpace(topicName))
@@ -40,7 +52,6 @@ public class EntityModelBuilder<T> : IEntityBuilder<T> where T : class
             ReplicationFactor = current.ReplicationFactor,
             RetentionMs = current.RetentionMs,
             Compaction = current.Compaction,
-            DeadLetterQueue = current.DeadLetterQueue,
             Description = current.Description,
             MaxMessageBytes = current.MaxMessageBytes,
             SegmentBytes = current.SegmentBytes,

--- a/src/Messaging/Producers/DlqProducer.cs
+++ b/src/Messaging/Producers/DlqProducer.cs
@@ -15,7 +15,7 @@ namespace Kafka.Ksql.Linq.Messaging.Producers;
 internal class DlqProducer : IErrorSink, IDisposable
 {
     private readonly KafkaProducerManager _producerManager;
-    private readonly string _dlqTopicSuffix;
+    private readonly string _dlqTopicName;
     private readonly DlqOptions _options;
     private bool _isInitialized = false;
     private bool _disposed = false;
@@ -26,7 +26,7 @@ internal class DlqProducer : IErrorSink, IDisposable
     {
         _producerManager = producerManager ?? throw new ArgumentNullException(nameof(producerManager));
         _options = options ?? new DlqOptions();
-        _dlqTopicSuffix = _options.TopicSuffix;
+        _dlqTopicName = _options.TopicName;
     }
 
     /// <summary>
@@ -42,15 +42,14 @@ internal class DlqProducer : IErrorSink, IDisposable
         try
         {
             var dlqMessage = CreateDlqMessage(errorContext, messageContext);
-            var dlqTopicName = GenerateDlqTopicName(messageContext);
 
             // DLQトピックに送信
-            await SendToDlqTopicAsync(dlqTopicName, dlqMessage);
+            await SendToDlqTopicAsync(dlqMessage);
 
             // メトリクス更新
             _options.MetricsCallback?.Invoke(new DlqMetrics
             {
-                TopicName = dlqTopicName,
+                TopicName = _dlqTopicName,
                 OriginalTopic = messageContext.Tags.GetValueOrDefault("original_topic")?.ToString() ?? "unknown",
                 ErrorType = errorContext.Exception.GetType().Name,
                 ProcessedAt = DateTime.UtcNow
@@ -149,23 +148,39 @@ internal class DlqProducer : IErrorSink, IDisposable
     }
 
     /// <summary>
-    /// DLQトピック名の生成
+    /// DLQトピックへの送信
     /// </summary>
-    private string GenerateDlqTopicName(KafkaMessageContext messageContext)
+    private async Task SendToDlqTopicAsync(DlqEnvelope dlqMessage)
     {
-        var originalTopic = messageContext.Tags.GetValueOrDefault("original_topic")?.ToString() ?? "unknown";
-        return $"{originalTopic}{_dlqTopicSuffix}";
+        await _producerManager.SendAsync(_dlqTopicName, dlqMessage);
     }
 
     /// <summary>
-    /// DLQトピックへの送信
+    /// デシリアライズ失敗データをDLQへ送信
     /// </summary>
-    private async Task SendToDlqTopicAsync(string dlqTopicName, DlqEnvelope dlqMessage)
+    public async Task SendAsync(byte[]? data, Exception exception, string originalTopic)
     {
-        // TODO: 実際のProducerManager経由での送信実装
-        // 現在は仮実装
-        Console.WriteLine($"[DLQ] Sending to topic: {dlqTopicName}");
-        await Task.Delay(10); // 送信模擬
+        var context = new KafkaMessageContext
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            Tags = new Dictionary<string, object>
+            {
+                ["original_topic"] = originalTopic,
+                ["error_phase"] = "Deserialization"
+            }
+        };
+
+        var errorContext = new ErrorContext
+        {
+            Exception = exception,
+            OriginalMessage = data,
+            AttemptCount = 1,
+            FirstAttemptTime = DateTime.UtcNow,
+            LastAttemptTime = DateTime.UtcNow,
+            ErrorPhase = "Deserialization"
+        };
+
+        await HandleErrorAsync(errorContext, context);
     }
 
     public void Dispose()
@@ -183,7 +198,11 @@ internal class DlqProducer : IErrorSink, IDisposable
 /// </summary>
 public class DlqOptions
 {
-    public string TopicSuffix { get; set; } = "_dlq";
+    /// <summary>
+    /// 共通DLQトピック名
+    /// </summary>
+    public string TopicName { get; set; } = "dead.letter.queue";
+
     public bool EnableCompression { get; set; } = true;
     public int MaxRetryAttempts { get; set; } = 3;
     public TimeSpan RetryInterval { get; set; } = TimeSpan.FromSeconds(1);

--- a/tasks/implement_diff_completion/coverage.md
+++ b/tasks/implement_diff_completion/coverage.md
@@ -18,6 +18,6 @@
 | Query & Subscription | yield型ForEachAsyncでのtry-catch | ✅ 実装済 | foreach_trycatch_support | |
 | Special Types | char型警告 | ✅ 実装済 | special_type_handling | ModelBuilderで警告 |
 | Special Types | short型自動int変換 | ✅ 実装済 | special_type_handling | DDL/Avro変換対応 |
-| Error Handling | チェーン可能なエラー処理DSL | ⏳ 部分実装 | chainable_error_dsl | OnError→Map→Retryの連鎖未完成 |
-| Error Handling | デシリアライズエラーポリシー | ❌ 未実装 | deserialization_error_policy | |
-| Error Handling | ModelBuilderでのDLQ設定 | ⏳ 部分実装 | dlq_configuration_support | TopicAttributeには存在 |
+| Error Handling | チェーン可能なエラー処理DSL | ✅ 実装済 | chainable_error_dsl | EventSetErrorHandlingExtensionsで実装 |
+| Error Handling | デシリアライズエラーポリシー | ✅ 実装済 | deserialization_error_policy | 失敗バイト列をDLQへ送信 |
+| Error Handling | ModelBuilderでのDLQ設定 | ❌ 未実装 | dlq_configuration_support | グローバルDLQ固定 |


### PR DESCRIPTION
## Summary
- inject `DlqProducer` into `KafkaConsumer`
- add `SendAsync` API and explicit topic support to `KafkaProducerManager`
- send deserialization errors to the configured DLQ topic
- initialize the global DLQ producer inside `KsqlContext`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e686244e88327b80e73f2c39d3ae8