### PR TITLE
Rename KafkaContext to KsqlContext

### DIFF
--- a/src/Core/Abstractions/IEntitySet.cs
+++ b/src/Core/Abstractions/IEntitySet.cs
@@ -25,5 +25,5 @@ public interface IEntitySet<T> : IAsyncEnumerable<T> where T : class
     // Metadata
     string GetTopicName();
     EntityModel GetEntityModel();
-    IKafkaContext GetContext();
+    IKsqlContext GetContext();
 }

--- a/src/Core/Abstractions/IKsqlContext.cs
+++ b/src/Core/Abstractions/IKsqlContext.cs
@@ -5,10 +5,10 @@ using System.Collections.Generic;
 namespace Kafka.Ksql.Linq.Core.Abstractions;
 
 /// <summary>
-/// KafkaContextの抽象定義
+/// KsqlContextの抽象定義
 /// DbContext風の統一インターフェース
 /// </summary>
-public interface IKafkaContext : IDisposable, IAsyncDisposable
+public interface IKsqlContext : IDisposable, IAsyncDisposable
 {
     IEntitySet<T> Set<T>() where T : class;
     object GetEventSet(Type entityType);

--- a/src/Core/Context/KafkaContextCore.cs
+++ b/src/Core/Context/KafkaContextCore.cs
@@ -13,7 +13,7 @@ namespace Kafka.Ksql.Linq.Core.Context;
 /// 制約: 完全ログフリー、副作用なし（Phase3 ログフリー版）
 /// ログ処理: Infrastructure層で実装
 /// </summary>
-public abstract class KafkaContextCore : IKafkaContext
+public abstract class KafkaContextCore : IKsqlContext
 {
     private readonly Dictionary<Type, EntityModel> _entityModels = new();
     private readonly Dictionary<Type, object> _entitySets = new();
@@ -32,7 +32,7 @@ public abstract class KafkaContextCore : IKafkaContext
         InitializeEntityModels();
     }
     protected virtual void OnModelCreating(IModelBuilder modelBuilder) { }
-    // ✅ IKafkaContext実装: エンティティセット取得（純粋関数）
+    // ✅ IKsqlContext実装: エンティティセット取得（純粋関数）
     public IEntitySet<T> Set<T>() where T : class
     {
         var entityType = typeof(T);
@@ -49,7 +49,7 @@ public abstract class KafkaContextCore : IKafkaContext
         return entitySet;
     }
 
-    // ✅ IKafkaContext実装: 非ジェネリック エンティティセット取得
+    // ✅ IKsqlContext実装: 非ジェネリック エンティティセット取得
     public object GetEventSet(Type entityType)
     {
         if (_entitySets.TryGetValue(entityType, out var entitySet))
@@ -64,7 +64,7 @@ public abstract class KafkaContextCore : IKafkaContext
         return createdSet;
     }
 
-    // ✅ IKafkaContext実装: エンティティモデル取得（純粋関数）
+    // ✅ IKsqlContext実装: エンティティモデル取得（純粋関数）
     public Dictionary<Type, EntityModel> GetEntityModels()
     {
         return new Dictionary<Type, EntityModel>(_entityModels);

--- a/src/Core/CoreDependencyConfiguration.cs
+++ b/src/Core/CoreDependencyConfiguration.cs
@@ -20,7 +20,7 @@ internal static class CoreDependencyConfiguration
     {
         var coreTypes = new[]
         {
-            typeof(IKafkaContext),
+            typeof(IKsqlContext),
             typeof(IEntitySet<>),
             typeof(ISerializationManager<>)
 

--- a/src/Core/CoreLayerValidation.cs
+++ b/src/Core/CoreLayerValidation.cs
@@ -28,7 +28,7 @@ internal static class CoreLayerValidation
     public static ValidationResult ValidateCoreDependencies()  // ✅ 修正: Core.Abstractions.ValidationResult 使用
     {
         var result = new ValidationResult { IsValid = true };  // ✅ 修正: Core.Abstractions.ValidationResult 使用
-        var coreAssembly = typeof(IKafkaContext).Assembly;
+        var coreAssembly = typeof(IKsqlContext).Assembly;
         var coreTypes = coreAssembly.GetTypes()
             .Where(t => t.Namespace?.StartsWith("Kafka.Ksql.Linq.Core") == true);
 

--- a/src/Core/Window/WindowAggregatedEntitySet.cs
+++ b/src/Core/Window/WindowAggregatedEntitySet.cs
@@ -101,7 +101,7 @@ internal class WindowAggregatedEntitySet<TSource, TKey, TResult> : IEntitySet<TR
 
     public EntityModel GetEntityModel() => _resultEntityModel;
 
-    public IKafkaContext GetContext() => _sourceEntitySet.GetContext();
+    public IKsqlContext GetContext() => _sourceEntitySet.GetContext();
 
     // ✅ IAsyncEnumerable<TResult> インターフェース実装
     public async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/Core/Window/WindowedEntitySet.cs
+++ b/src/Core/Window/WindowedEntitySet.cs
@@ -124,7 +124,7 @@ internal class WindowedEntitySet<T> : IWindowedEntitySet<T> where T : class
 
     public EntityModel GetEntityModel() => _baseEntitySet.GetEntityModel();
 
-    public IKafkaContext GetContext() => _baseEntitySet.GetContext();
+    public IKsqlContext GetContext() => _baseEntitySet.GetContext();
 
     // ✅ IAsyncEnumerable<T> インターフェース実装
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/EventSet.cs
+++ b/src/EventSet.cs
@@ -12,16 +12,16 @@ namespace Kafka.Ksql.Linq;
 
 /// <summary>
 /// EventSet基底クラス - IEntitySet<T>を実装
-/// 修正理由: KafkaContextとの統合、IEntitySet<T>実装追加
+/// 修正理由: KsqlContextとの統合、IEntitySet<T>実装追加
 /// </summary>
 public abstract class EventSet<T> : IEntitySet<T> where T : class
 {
-    protected readonly IKafkaContext _context;
+    protected readonly IKsqlContext _context;
     protected readonly EntityModel _entityModel;
     private readonly ErrorHandlingContext _errorHandlingContext;
     private readonly IErrorSink? _dlqErrorSink;
 
-    protected EventSet(IKafkaContext context, EntityModel entityModel, IErrorSink? dlqErrorSink = null)
+    protected EventSet(IKsqlContext context, EntityModel entityModel, IErrorSink? dlqErrorSink = null)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _entityModel = entityModel ?? throw new ArgumentNullException(nameof(entityModel));
@@ -29,7 +29,7 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
         _dlqErrorSink = dlqErrorSink;
     }
 
-    private EventSet(IKafkaContext context, EntityModel entityModel, ErrorHandlingContext errorHandlingContext, IErrorSink? dlqErrorSink)
+    private EventSet(IKsqlContext context, EntityModel entityModel, ErrorHandlingContext errorHandlingContext, IErrorSink? dlqErrorSink)
     {
         _context = context;
         _entityModel = entityModel;
@@ -164,7 +164,7 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
 
     public EntityModel GetEntityModel() => _entityModel;
 
-    public IKafkaContext GetContext() => _context;
+    public IKsqlContext GetContext() => _context;
 
     /// <summary>
     /// エラーハンドリング用メッセージコンテキスト作成
@@ -318,7 +318,7 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
     }
 
     // ✅ 抽象メソッド：派生クラスで新しいインスタンス作成
-    protected virtual EventSet<T> CreateNewInstance(IKafkaContext context, EntityModel entityModel, ErrorHandlingContext errorContext, IErrorSink? dlqErrorSink)
+    protected virtual EventSet<T> CreateNewInstance(IKsqlContext context, EntityModel entityModel, ErrorHandlingContext errorContext, IErrorSink? dlqErrorSink)
     {
         // デフォルト実装：具象クラスでオーバーライド必要
         throw new NotImplementedException("Derived classes must implement CreateNewInstance");
@@ -456,7 +456,7 @@ internal class MappedEventSet<T> : EventSet<T> where T : class
     private readonly List<T> _mapped;
     private readonly EntityModel _originalEntityModel;
 
-    public MappedEventSet(List<T> mappedItems, IKafkaContext context, EntityModel originalEntityModel, IErrorSink? errorSink = null)
+    public MappedEventSet(List<T> mappedItems, IKsqlContext context, EntityModel originalEntityModel, IErrorSink? errorSink = null)
         : base(context, CreateMappedEntityModel<T>(originalEntityModel), errorSink)
     {
         _mapped = mappedItems ?? throw new ArgumentNullException(nameof(mappedItems));
@@ -504,7 +504,7 @@ internal class MappedEventSet<T> : EventSet<T> where T : class
     /// <summary>
     /// MappedEventSet作成用ヘルパーメソッド
     /// </summary>
-    public static MappedEventSet<T> Create(List<T> mappedItems, IKafkaContext context, EntityModel originalEntityModel, IErrorSink? errorSink = null)
+    public static MappedEventSet<T> Create(List<T> mappedItems, IKsqlContext context, EntityModel originalEntityModel, IErrorSink? errorSink = null)
     {
         return new MappedEventSet<T>(mappedItems, context, originalEntityModel, errorSink);
     }
@@ -512,7 +512,7 @@ internal class MappedEventSet<T> : EventSet<T> where T : class
     /// <summary>
     /// DLQ対応MappedEventSet作成
     /// </summary>
-    public static MappedEventSet<T> CreateWithDlq(List<T> mappedItems, IKafkaContext context, EntityModel originalEntityModel, IErrorSink dlqErrorSink)
+    public static MappedEventSet<T> CreateWithDlq(List<T> mappedItems, IKsqlContext context, EntityModel originalEntityModel, IErrorSink dlqErrorSink)
     {
         return new MappedEventSet<T>(mappedItems, context, originalEntityModel, dlqErrorSink);
     }

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -412,7 +412,7 @@ internal class EventSetWithServices<T> : IEntitySet<T> where T : class
     // Metadata取得
     public string GetTopicName() => _entityModel.TopicAttribute?.TopicName ?? typeof(T).Name;
     public EntityModel GetEntityModel() => _entityModel;
-    public IKafkaContext GetContext() => _ksqlContext;
+    public IKsqlContext GetContext() => _ksqlContext;
 
     public override string ToString()
     {

--- a/src/Query/Abstractions/IEventSet.cs
+++ b/src/Query/Abstractions/IEventSet.cs
@@ -38,5 +38,5 @@ internal interface IEventSet<T> : IQueryable<T>, IAsyncEnumerable<T> where T : c
     // Metadata Access
     string GetTopicName();
     EntityModel GetEntityModel();
-    IKafkaContext GetContext();
+    IKsqlContext GetContext();
 }

--- a/src/Query/Linq/JoinResultEntitySet.cs
+++ b/src/Query/Linq/JoinResultEntitySet.cs
@@ -9,13 +9,13 @@ namespace Kafka.Ksql.Linq.Query.Linq;
 
 internal class JoinResultEntitySet<T> : IEntitySet<T> where T : class
 {
-    private readonly IKafkaContext _context;
+    private readonly IKsqlContext _context;
     private readonly EntityModel _entityModel;
     private readonly Expression _joinExpression;
     private readonly JoinBuilder _joinBuilder;
 
     public JoinResultEntitySet(
-        IKafkaContext context,
+        IKsqlContext context,
         EntityModel entityModel,
         Expression joinExpression,
         JoinBuilder joinBuilder)
@@ -55,7 +55,7 @@ internal class JoinResultEntitySet<T> : IEntitySet<T> where T : class
 
     public EntityModel GetEntityModel() => _entityModel;
 
-    public IKafkaContext GetContext() => _context;
+    public IKsqlContext GetContext() => _context;
 
     // ✅ IAsyncEnumerable<T>の実装
     public async System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/Query/Linq/JoinableEntitySet.cs
+++ b/src/Query/Linq/JoinableEntitySet.cs
@@ -39,7 +39,7 @@ public class JoinableEntitySet<T> : IEntitySet<T>, IJoinableEntitySet<T> where T
 
     public EntityModel GetEntityModel() => _baseEntitySet.GetEntityModel();
 
-    public IKafkaContext GetContext() => _baseEntitySet.GetContext();
+    public IKsqlContext GetContext() => _baseEntitySet.GetContext();
 
     // ✅ IAsyncEnumerable<T> の実装
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -227,7 +227,7 @@ internal class TypedJoinResultEntitySet<TOuter, TInner, TResult> : IEntitySet<TR
        where TInner : class
        where TResult : class
 {
-    private readonly IKafkaContext _context;
+    private readonly IKsqlContext _context;
     private readonly EntityModel _entityModel;
     private readonly IEntitySet<TOuter> _outerEntitySet;
     private readonly IEntitySet<TInner> _innerEntitySet;
@@ -236,7 +236,7 @@ internal class TypedJoinResultEntitySet<TOuter, TInner, TResult> : IEntitySet<TR
     private readonly Expression<Func<TOuter, TInner, TResult>> _resultSelector;
 
     public TypedJoinResultEntitySet(
-        IKafkaContext context,
+        IKsqlContext context,
         EntityModel entityModel,
         IEntitySet<TOuter> outerEntitySet,
         IEntitySet<TInner> innerEntitySet,
@@ -272,7 +272,7 @@ internal class TypedJoinResultEntitySet<TOuter, TInner, TResult> : IEntitySet<TR
 
     public string GetTopicName() => _entityModel.TopicAttribute?.TopicName ?? typeof(TResult).Name;
     public EntityModel GetEntityModel() => _entityModel;
-    public IKafkaContext GetContext() => _context;
+    public IKsqlContext GetContext() => _context;
 
     public async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
@@ -291,7 +291,7 @@ internal class TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult>
     where TThird : class
     where TResult : class
 {
-    private readonly IKafkaContext _context;
+    private readonly IKsqlContext _context;
     private readonly EntityModel _entityModel;
     private readonly IEntitySet<TOuter> _outerEntitySet;
     private readonly IEntitySet<TInner> _innerEntitySet;
@@ -303,7 +303,7 @@ internal class TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult>
     private readonly Expression<Func<TOuter, TInner, TThird, TResult>> _resultSelector;
 
     public TypedThreeWayJoinResultEntitySet(
-        IKafkaContext context,
+        IKsqlContext context,
         EntityModel entityModel,
         IEntitySet<TOuter> outerEntitySet,
         IEntitySet<TInner> innerEntitySet,
@@ -345,7 +345,7 @@ internal class TypedThreeWayJoinResultEntitySet<TOuter, TInner, TThird, TResult>
 
     public string GetTopicName() => _entityModel.TopicAttribute?.TopicName ?? typeof(TResult).Name;
     public EntityModel GetEntityModel() => _entityModel;
-    public IKafkaContext GetContext() => _context;
+    public IKsqlContext GetContext() => _context;
 
     public async IAsyncEnumerator<TResult> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
@@ -392,7 +392,7 @@ internal class EntitySetAdapter<T> : IEntitySet<object> where T : class
 
     public string GetTopicName() => _inner.GetTopicName();
     public EntityModel GetEntityModel() => _inner.GetEntityModel();
-    public IKafkaContext GetContext() => _inner.GetContext();
+    public IKsqlContext GetContext() => _inner.GetContext();
 
     public async IAsyncEnumerator<object> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {

--- a/src/Query/Linq/UnifiedJoinResult.cs
+++ b/src/Query/Linq/UnifiedJoinResult.cs
@@ -18,7 +18,7 @@ internal class UnifiedJoinResult<TOuter, TInner> : IJoinResult<TOuter, TInner>
     private readonly Expression _outerKeySelector;
     private readonly Expression _innerKeySelector;
     private readonly JoinBuilder _joinBuilder;
-    private readonly IKafkaContext _context;
+    private readonly IKsqlContext _context;
 
     public UnifiedJoinResult(
         IEntitySet<TOuter> outer,
@@ -26,7 +26,7 @@ internal class UnifiedJoinResult<TOuter, TInner> : IJoinResult<TOuter, TInner>
         Expression outerKeySelector,
         Expression innerKeySelector,
         JoinBuilder joinBuilder,
-        IKafkaContext context)
+        IKsqlContext context)
     {
         _outer = outer ?? throw new ArgumentNullException(nameof(outer));
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));

--- a/src/Query/Linq/UnifiedThreeWayJoinResult.cs
+++ b/src/Query/Linq/UnifiedThreeWayJoinResult.cs
@@ -23,7 +23,7 @@ internal class UnifiedThreeWayJoinResult<TOuter, TInner, TThird> : IJoinResult<T
     private readonly Expression _thirdKeySelector;
     private readonly JoinKeySource _secondJoinKeySource;
     private readonly JoinBuilder _joinBuilder;
-    private readonly IKafkaContext _context;
+    private readonly IKsqlContext _context;
 
     public UnifiedThreeWayJoinResult(
         IEntitySet<TOuter> outer,
@@ -35,7 +35,7 @@ internal class UnifiedThreeWayJoinResult<TOuter, TInner, TThird> : IJoinResult<T
         Expression thirdKeySelector,
         JoinKeySource secondJoinKeySource,
         JoinBuilder joinBuilder,
-        IKafkaContext context)
+        IKsqlContext context)
     {
         _outer = outer;
         _inner = inner;

--- a/src/StateStore/EventSetWithStateStore.cs
+++ b/src/StateStore/EventSetWithStateStore.cs
@@ -16,11 +16,11 @@ namespace Kafka.Ksql.Linq.StateStore;
 /// </summary>
 internal class EventSetWithStateStore<T> : IEntitySet<T> where T : class
 {
-    private readonly IKafkaContext _context;
+    private readonly IKsqlContext _context;
     private readonly EntityModel _entityModel;
     private readonly IEntitySet<T> _baseEntitySet;
 
-    internal EventSetWithStateStore(IKafkaContext context, EntityModel entityModel)
+    internal EventSetWithStateStore(IKsqlContext context, EntityModel entityModel)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _entityModel = entityModel ?? throw new ArgumentNullException(nameof(entityModel));
@@ -110,7 +110,7 @@ internal class EventSetWithStateStore<T> : IEntitySet<T> where T : class
         return _entityModel;
     }
 
-    public IKafkaContext GetContext()
+    public IKsqlContext GetContext()
     {
         return _context;
     }
@@ -125,14 +125,14 @@ internal class EventSetWithStateStore<T> : IEntitySet<T> where T : class
 }
 
 /// <summary>
-/// IKafkaContext拡張メソッド（StateStore統合用）
+/// IKsqlContext拡張メソッド（StateStore統合用）
 /// </summary>
 internal static class KafkaContextStateStoreIntegrationExtensions
 {
     /// <summary>
     /// StateStore機能付きEntitySetを取得
     /// </summary>
-    public static EventSetWithStateStore<T> SetWithStateStore<T>(this IKafkaContext context) where T : class
+    public static EventSetWithStateStore<T> SetWithStateStore<T>(this IKsqlContext context) where T : class
     {
         var entityModel = context.GetEntityModels().FirstOrDefault(x => x.Key == typeof(T)).Value;
         if (entityModel == null)

--- a/src/StateStore/Extensions/KafkaContextStateStoreExtensions.cs
+++ b/src/StateStore/Extensions/KafkaContextStateStoreExtensions.cs
@@ -9,10 +9,10 @@ namespace Kafka.Ksql.Linq.StateStore.Extensions;
 
 internal static class KafkaContextStateStoreExtensions
 {
-    private static readonly Dictionary<IKafkaContext, IStateStoreManager> _contextStoreManagers = new();
+    private static readonly Dictionary<IKsqlContext, IStateStoreManager> _contextStoreManagers = new();
     private static readonly object _lock = new();
 
-    internal static void InitializeStateStores(this IKafkaContext context, KsqlDslOptions options)
+    internal static void InitializeStateStores(this IKsqlContext context, KsqlDslOptions options)
     {
         lock (_lock)
         {
@@ -39,7 +39,7 @@ internal static class KafkaContextStateStoreExtensions
         }
     }
 
-    internal static IStateStoreManager? GetStateStoreManager(this IKafkaContext context)
+    internal static IStateStoreManager? GetStateStoreManager(this IKsqlContext context)
     {
         lock (_lock)
         {
@@ -47,7 +47,7 @@ internal static class KafkaContextStateStoreExtensions
         }
     }
 
-    internal static void CleanupStateStores(this IKafkaContext context)
+    internal static void CleanupStateStores(this IKsqlContext context)
     {
         lock (_lock)
         {

--- a/src/StateStore/Extensions/WindowExtensions.cs
+++ b/src/StateStore/Extensions/WindowExtensions.cs
@@ -7,7 +7,7 @@ namespace Kafka.Ksql.Linq.StateStore.Extensions;
 
 internal static class WindowExtensions
 {
-    private static readonly Dictionary<IKafkaContext, IStateStoreManager> _storeManagers = new();
+    private static readonly Dictionary<IKsqlContext, IStateStoreManager> _storeManagers = new();
     private static readonly object _lock = new();
 
     internal static IWindowedEntitySet<T> Window<T>(this IEntitySet<T> entitySet, int windowMinutes)
@@ -20,7 +20,7 @@ internal static class WindowExtensions
         return new WindowedEntitySet<T>(entitySet, windowMinutes, storeManager, entityModel);
     }
 
-    private static IStateStoreManager GetOrCreateStateStoreManager(IKafkaContext context)
+    private static IStateStoreManager GetOrCreateStateStoreManager(IKsqlContext context)
     {
         lock (_lock)
         {

--- a/src/StateStore/Extensions/WindowedEntitySet.cs
+++ b/src/StateStore/Extensions/WindowedEntitySet.cs
@@ -68,7 +68,7 @@ internal class WindowedEntitySet<T> : IWindowedEntitySet<T> where T : class
 
     public EntityModel GetEntityModel() => _entityModel;
 
-    public IKafkaContext GetContext() => _baseEntitySet.GetContext();
+    public IKsqlContext GetContext() => _baseEntitySet.GetContext();
 
     public async System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default)
     {

--- a/src/StateStore/WindowExtensions.cs
+++ b/src/StateStore/WindowExtensions.cs
@@ -7,7 +7,7 @@ namespace Kafka.Ksql.Linq.StateStore;
 
 internal static class WindowExtensions
 {
-    private static readonly Dictionary<IKafkaContext, StateStoreManager> _storeManagers = new();
+    private static readonly Dictionary<IKsqlContext, StateStoreManager> _storeManagers = new();
     private static readonly object _lock = new();
 
     internal static IWindowedEntitySet<T> Window<T>(this IEntitySet<T> entitySet, int windowMinutes)
@@ -20,7 +20,7 @@ internal static class WindowExtensions
         return new WindowedEntitySet<T>(entitySet, windowMinutes, storeManager, entityModel);
     }
 
-    private static StateStoreManager GetOrCreateStateStoreManager(IKafkaContext context)
+    private static StateStoreManager GetOrCreateStateStoreManager(IKsqlContext context)
     {
         lock (_lock)
         {

--- a/src/StateStore/WindowedEntitySet.cs
+++ b/src/StateStore/WindowedEntitySet.cs
@@ -66,7 +66,7 @@ internal class WindowedEntitySet<T> : IWindowedEntitySet<T> where T : class
 
     public EntityModel GetEntityModel() => _entityModel;
 
-    public IKafkaContext GetContext() => _baseEntitySet.GetContext();
+    public IKsqlContext GetContext() => _baseEntitySet.GetContext();
 
     public async System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
## Summary
- rename `IKafkaContext` to `IKsqlContext`
- update references across query and state store components
- adjust `KafkaContextCore` and related code to use the new interface

## Testing
- `dotnet` command not found, so build and tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_685e7c5441108327b8ff96e6f0384ac0