### PR TITLE
Remove centralized defaults

### DIFF
--- a/src/Configuration/DlqTopicConfiguration.cs
+++ b/src/Configuration/DlqTopicConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Configuration;
 
@@ -9,24 +10,28 @@ public class DlqTopicConfiguration
     /// DLQデータ保持時間（ミリ秒）
     /// デフォルト: 5000（5秒） - 一時退避先として機能
     /// </summary>
+    [DefaultValue(5000)]
     public long RetentionMs { get; set; } = 5000;
 
     /// <summary>
     /// DLQトピックパーティション数
     /// デフォルト: 1（可観測性目的、パフォーマンス重視ではない）
     /// </summary>
+    [DefaultValue(1)]
     public int NumPartitions { get; set; } = 1;
 
     /// <summary>
     /// DLQトピックレプリケーション係数
     /// デフォルト: 1（単一ブローカー環境対応）
     /// </summary>
+    [DefaultValue(1)]
     public short ReplicationFactor { get; set; } = 1;
 
     /// <summary>
     /// DLQトピック自動作成を有効にするか
     /// デフォルト: true（Fail-Fast防止）
     /// </summary>
+    [DefaultValue(true)]
     public bool EnableAutoCreation { get; set; } = true;
 
     /// <summary>

--- a/src/Configuration/KsqlDslOptions.cs
+++ b/src/Configuration/KsqlDslOptions.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Messaging.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
 using System.Collections.Generic;
 
 namespace Kafka.Ksql.Linq.Configuration;
@@ -27,6 +28,7 @@ public class KsqlDslOptions
 
     public List<EntityConfiguration> Entities { get; init; } = new();
 
+    [DefaultValue("dead.letter.queue")]
     public string DlqTopicName { get; set; } = "dead.letter.queue";
 
     public DlqTopicConfiguration DlqConfiguration { get; init; } = new();

--- a/src/Core/Abstractions/IWindowedEntitySet.cs
+++ b/src/Core/Abstractions/IWindowedEntitySet.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Core.Abstractions;
 
@@ -81,21 +82,25 @@ public record WindowAggregationConfig
     /// <summary>
     /// グレースピリオド（遅延許容時間）
     /// </summary>
+    [DefaultValue("00:00:03")]
     public TimeSpan GracePeriod { get; set; } = TimeSpan.FromSeconds(3);
 
     /// <summary>
     /// ウィンドウタイプ
     /// </summary>
+    [DefaultValue(WindowType.Tumbling)]
     public WindowType WindowType { get; set; } = WindowType.Tumbling;
 
     /// <summary>
     /// 出力モード
     /// </summary>
+    [DefaultValue(WindowOutputMode.Changes)]
     public WindowOutputMode OutputMode { get; set; } = WindowOutputMode.Changes;
 
     /// <summary>
     /// Heartbeatトピックの使用
     /// </summary>
+    [DefaultValue(true)]
     public bool UseHeartbeat { get; set; } = true;
 }
 

--- a/src/Core/Abstractions/TopicAttribute.cs
+++ b/src/Core/Abstractions/TopicAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Core.Abstractions;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
@@ -7,8 +8,10 @@ public class TopicAttribute : Attribute
 {
     public string TopicName { get; }
 
+    [DefaultValue(1)]
     public int PartitionCount { get; set; } = 1;
 
+    [DefaultValue(1)]
     public int ReplicationFactor { get; set; } = 1;
 
     /// <summary>
@@ -16,6 +19,7 @@ public class TopicAttribute : Attribute
     /// </summary>
     public int? MinInSyncReplicas { get; set; }
 
+    [DefaultValue(604800000)]
     public long RetentionMs { get; set; } = 604800000; // 7 days
 
     public bool Compaction { get; set; } = false;

--- a/src/Messaging/Configuration/ConsumerSection.cs
+++ b/src/Messaging/Configuration/ConsumerSection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Messaging.Configuration;
 
@@ -15,16 +16,19 @@ public class ConsumerSection
     /// <summary>
     /// オートオフセットリセット（Latest, Earliest, None）
     /// </summary>
+    [DefaultValue("Latest")]
     public string AutoOffsetReset { get; init; } = "Latest";
 
     /// <summary>
     /// 自動コミット有効化
     /// </summary>
+    [DefaultValue(true)]
     public bool EnableAutoCommit { get; init; } = true;
 
     /// <summary>
     /// 自動コミット間隔（ミリ秒）
     /// </summary>
+    [DefaultValue(5000)]
     public int AutoCommitIntervalMs { get; init; } = 5000;
 
     /// <summary>

--- a/src/Messaging/Configuration/ProducerSection.cs
+++ b/src/Messaging/Configuration/ProducerSection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Messaging.Configuration;
 public class ProducerSection
@@ -6,16 +7,19 @@ public class ProducerSection
     /// <summary>
     /// 確認応答レベル（All, Leader, None）
     /// </summary>
+    [DefaultValue("All")]
     public string Acks { get; init; } = "All";
 
     /// <summary>
     /// 圧縮タイプ
     /// </summary>
+    [DefaultValue("Snappy")]
     public string CompressionType { get; init; } = "Snappy";
 
     /// <summary>
     /// 冪等性有効化
     /// </summary>
+    [DefaultValue(true)]
     public bool EnableIdempotence { get; init; } = true;
 
     /// <summary>

--- a/src/Messaging/Configuration/TopicSection.cs
+++ b/src/Messaging/Configuration/TopicSection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Messaging.Configuration;
 
@@ -36,11 +37,13 @@ public class TopicCreationSection
     /// <summary>
     /// パーティション数
     /// </summary>
+    [DefaultValue(1)]
     public int NumPartitions { get; init; } = 1;
 
     /// <summary>
     /// レプリケーション係数
     /// </summary>
+    [DefaultValue(1)]
     public short ReplicationFactor { get; init; } = 1;
 
     /// <summary>

--- a/src/Messaging/Internal/ErrorHandlingContext.cs
+++ b/src/Messaging/Internal/ErrorHandlingContext.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Contracts;
+using Kafka.Ksql.Linq.Core.Attributes;
 using System;
 using System.Threading.Tasks;
 
@@ -9,16 +10,19 @@ public class ErrorHandlingContext
     /// <summary>
     /// エラー発生時のアクション
     /// </summary>
+    [DefaultValue(ErrorAction.Skip)]
     public ErrorAction ErrorAction { get; set; } = ErrorAction.Skip;
 
     /// <summary>
     /// リトライ回数
     /// </summary>
+    [DefaultValue(3)]
     public int RetryCount { get; set; } = 3;
 
     /// <summary>
     /// リトライ間隔
     /// </summary>
+    [DefaultValue("00:00:01")]
     public TimeSpan RetryInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     /// <summary>

--- a/src/Messaging/Producers/DlqProducer.cs
+++ b/src/Messaging/Producers/DlqProducer.cs
@@ -1,7 +1,7 @@
-using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Contracts;
+using Kafka.Ksql.Linq.Core.Attributes;
 using Confluent.Kafka;
 using KsqlDsl.Messaging.Models;
 using Microsoft.Extensions.Logging;
@@ -258,10 +258,13 @@ public class DlqOptions
     /// <summary>
     /// 共通DLQトピック名
     /// </summary>
+    [DefaultValue("dead.letter.queue")]
     public string TopicName { get; set; } = "dead.letter.queue";
 
     public bool EnableCompression { get; set; } = true;
+    [DefaultValue(3)]
     public int MaxRetryAttempts { get; set; } = 3;
+    [DefaultValue("00:00:01")]
     public TimeSpan RetryInterval { get; set; } = TimeSpan.FromSeconds(1);
     public Action<DlqMetrics>? MetricsCallback { get; set; }
 }

--- a/tasks/config_generation_with_defaults/validation_log.md
+++ b/tasks/config_generation_with_defaults/validation_log.md
@@ -1,0 +1,25 @@
+# Config Defaults Validation Log
+
+- Total checks: 20
+- Result: No mismatches found.
+
+OK PartitionCount = 1
+OK ReplicationFactor = 1
+OK RetentionMs = 604800000
+OK Acks = All
+OK CompressionType = Snappy
+OK EnableIdempotence = true
+OK AutoOffsetReset = Latest
+OK EnableAutoCommit = true
+OK AutoCommitIntervalMs = 5000
+OK RetentionMs = 5000
+OK NumPartitions = 1
+OK ReplicationFactor = 1
+OK EnableAutoCreation = true
+OK WindowType = Tumbling
+OK GracePeriod = 3
+OK OutputMode = Changes
+OK UseHeartbeat = true
+OK ErrorAction = Skip
+OK RetryCount = 3
+OK RetryInterval = 1

--- a/tools/validate_defaults.py
+++ b/tools/validate_defaults.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import os
+import re
+
+def get_doc_value(text, key):
+    # Special handling for ErrorHandlingContext defaults described in sentence form
+    if key in {"ErrorAction", "RetryCount", "RetryInterval"}:
+        m = re.search(r"ErrorHandlingContext[^`]*`?[^E]*ErrorAction=([^`,]+)`,\s*`RetryCount=([^`,]+)`,\s*`RetryInterval=([^`]+)`", text)
+        if m:
+            mapping = {
+                "ErrorAction": m.group(1).strip(),
+                "RetryCount": m.group(2).strip(),
+                "RetryInterval": m.group(3).strip(),
+            }
+            val = mapping[key]
+            if '(' in val:
+                val = val.split('(')[0].strip()
+            val = val.replace('秒', '').strip()
+            val = re.sub(r'[^0-9A-Za-z_.-]', '', val)
+            return val.strip('"').strip('`')
+        return '<missing>'
+    section = None
+    if key.startswith('DLQ.'):
+        key = key.split('.',1)[1]
+        section = 'DLQ'
+    pattern = rf"\| {re.escape(key)} \|([^|]+)\|"
+    if section:
+        sec_match = re.search(rf"## {section}構成(.*?)##", text, re.S)
+        search_area = sec_match.group(1) if sec_match else text
+    else:
+        search_area = text
+    m = re.search(pattern, search_area)
+    if not m:
+        return '<missing>'
+    val = m.group(1).strip()
+    if '(' in val:
+        val = val.split('(')[0].strip()
+    val = val.replace('秒', '').strip()
+    val = re.sub(r'[^0-9A-Za-z_.-]', '', val)
+    return val.strip('"').strip('`')
+
+def get_code_value(path, prop):
+    with open(path, encoding='utf-8') as f:
+        text = f.read()
+    m = re.search(rf"{re.escape(prop)}.*=\s*([^;]+);", text)
+    if not m:
+        return '<missing>'
+    val = m.group(1).strip()
+    val = val.strip('"')
+    if val.startswith("TimeSpan.FromSeconds("):
+        val = val.replace("TimeSpan.FromSeconds(", "").rstrip(")")
+    if val.startswith("WindowType."):
+        val = val.split('.',1)[1]
+    if val.startswith("WindowOutputMode."):
+        val = val.split('.',1)[1]
+    if val.startswith("ErrorAction."):
+        val = val.split('.',1)[1]
+    return val
+
+def check(file_path, prop, doc_key):
+    expected = get_doc_value(docs, doc_key)
+    actual = get_code_value(file_path, prop)
+    if expected != actual:
+        return f"Mismatch {prop}: doc={expected} code={actual}"
+    return f"OK {prop} = {actual}"
+
+docs = open(os.path.join('docs','defaults.md'), encoding='utf-8').read()
+
+checks = [
+    ('src/Core/Abstractions/TopicAttribute.cs','PartitionCount','PartitionCount'),
+    ('src/Core/Abstractions/TopicAttribute.cs','ReplicationFactor','ReplicationFactor'),
+    ('src/Core/Abstractions/TopicAttribute.cs','RetentionMs','RetentionMs'),
+    ('src/Messaging/Configuration/ProducerSection.cs','Acks','Producer.Acks'),
+    ('src/Messaging/Configuration/ProducerSection.cs','CompressionType','Producer.CompressionType'),
+    ('src/Messaging/Configuration/ProducerSection.cs','EnableIdempotence','Producer.EnableIdempotence'),
+    ('src/Messaging/Configuration/ConsumerSection.cs','AutoOffsetReset','Consumer.AutoOffsetReset'),
+    ('src/Messaging/Configuration/ConsumerSection.cs','EnableAutoCommit','Consumer.EnableAutoCommit'),
+    ('src/Messaging/Configuration/ConsumerSection.cs','AutoCommitIntervalMs','Consumer.AutoCommitIntervalMs'),
+    ('src/Configuration/DlqTopicConfiguration.cs','RetentionMs','DLQ.RetentionMs'),
+    ('src/Configuration/DlqTopicConfiguration.cs','NumPartitions','NumPartitions'),
+    ('src/Configuration/DlqTopicConfiguration.cs','ReplicationFactor','ReplicationFactor'),
+    ('src/Configuration/DlqTopicConfiguration.cs','EnableAutoCreation','EnableAutoCreation'),
+    ('src/Core/Abstractions/IWindowedEntitySet.cs','WindowType','WindowType'),
+    ('src/Core/Abstractions/IWindowedEntitySet.cs','GracePeriod','GracePeriod'),
+    ('src/Core/Abstractions/IWindowedEntitySet.cs','OutputMode','OutputMode'),
+    ('src/Core/Abstractions/IWindowedEntitySet.cs','UseHeartbeat','UseHeartbeat'),
+    ('src/Messaging/Internal/ErrorHandlingContext.cs','ErrorAction','ErrorAction'),
+    ('src/Messaging/Internal/ErrorHandlingContext.cs','RetryCount','RetryCount'),
+    ('src/Messaging/Internal/ErrorHandlingContext.cs','RetryInterval','RetryInterval'),
+]
+
+results = [check(f,p,k) for f,p,k in checks]
+
+mism = [r for r in results if r.startswith('Mismatch')]
+print('# Config Defaults Validation Log')
+print()
+print(f'- Total checks: {len(checks)}')
+if mism:
+    print(f'- Result: {len(mism)} mismatches found')
+else:
+    print('- Result: No mismatches found.')
+print()
+for r in results:
+    print(r)


### PR DESCRIPTION
## Summary
- remove `Defaults` static class and embed default constants directly
- annotate configuration properties with immediate values
- update DLQ setup with literal defaults and cleanup policy
- keep validator to check against `docs/defaults.md`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e828596208327873fd41fd92b3cbe