### PR TITLE
Add namespace log level configuration support

### DIFF
--- a/docs/api_public_methods.md
+++ b/docs/api_public_methods.md
@@ -674,6 +674,7 @@
 - `public KsqlContextBuilder UseSchemaRegistry(ISchemaRegistryClient client)`
 - `public KsqlContextBuilder UseSchemaRegistry(SchemaRegistryConfig config)`
 - `public KsqlContextBuilder UseSchemaRegistry(string url)`
+- `public KsqlContextBuilder UseConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration)`
 - `public KsqlContextBuilder WithTimeouts(TimeSpan schemaRegistrationTimeout)`
 - `public KsqlContextOptions Build()`
 - `public T BuildContext<T>() where T : KsqlContext`
@@ -684,6 +685,7 @@
 - `public void BuildContext_CreatesInstance()`
 - `public void Builder_Methods_ConfigureOptions()`
 - `public void Create_ReturnsBuilder()`
+- `public void UseConfiguration_SetsOptions()`
 
 ### KsqlContextConversionTests
 
@@ -768,12 +770,14 @@
 - `public static void LogErrorWithLegacySupport<T>(this ILogger<T> logger,`
 - `public static void LogInformationWithLegacySupport<T>(this ILogger<T> logger,`
 - `public static void LogWarningWithLegacySupport<T>(this ILogger<T> logger,`
+- `public static Microsoft.Extensions.Logging.ILoggerFactory CreateLoggerFactory(this Microsoft.Extensions.Configuration.IConfiguration configuration)`
 
 ### LoggerFactoryExtensionsTests
 
 - `public void CreateLoggerOrNull_ReturnsNullLoggerWhenFactoryNull()`
 - `public void CreateLoggerOrNull_UsesFactory()`
 - `public void LogMethods_WithAndWithoutFactory()`
+- `public void CreateLoggerFactory_FromConfiguration_RespectsNamespaceLevels()`
 
 ### ManagedTopicExtensions
 

--- a/src/Application/KsqlContextBuilder.cs
+++ b/src/Application/KsqlContextBuilder.cs
@@ -1,5 +1,6 @@
 using Confluent.SchemaRegistry;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 using System;
 namespace Kafka.Ksql.Linq.Application;
 public class KsqlContextBuilder
@@ -9,6 +10,13 @@ public class KsqlContextBuilder
     public static KsqlContextBuilder Create()
     {
         return new KsqlContextBuilder();
+    }
+
+    public KsqlContextBuilder UseConfiguration(IConfiguration configuration)
+    {
+        if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+        _options.Configuration = configuration;
+        return this;
     }
 
     public KsqlContextBuilder UseSchemaRegistry(string url)

--- a/src/Application/KsqlContextOptions.cs
+++ b/src/Application/KsqlContextOptions.cs
@@ -6,6 +6,7 @@ public class KsqlContextOptions
 {
     public ISchemaRegistryClient SchemaRegistryClient { get; set; } = null!;
     public ILoggerFactory? LoggerFactory { get; set; }
+    public Microsoft.Extensions.Configuration.IConfiguration? Configuration { get; set; }
     public bool EnableDebugLogging { get; set; } = false;
     public bool AutoRegisterSchemas { get; set; } = true;
     public bool EnableCachePreWarming { get; set; } = true;

--- a/src/Core/Extensions/LoggerFactoryExtensions.cs
+++ b/src/Core/Extensions/LoggerFactoryExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Configuration;
 using System;
 
 namespace Kafka.Ksql.Linq.Core.Extensions;
@@ -161,4 +162,22 @@ public static class LoggerFactoryExtensions
             Console.WriteLine($"[ERROR] Exception: {exception.Message}");
         }
     }
+
+    /// <summary>
+    /// appsettings.json の Logging セクションから LoggerFactory を生成する
+    /// </summary>
+    /// <param name="configuration">構成情報</param>
+    /// <returns>設定済みの ILoggerFactory</returns>
+    public static ILoggerFactory CreateLoggerFactory(this IConfiguration configuration)
+    {
+        if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+
+        return LoggerFactory.Create(builder =>
+        {
+            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddConsole();
+            builder.AddDebug();
+        });
+    }
 }
+

--- a/src/Kafka.Ksql.Linq.csproj
+++ b/src/Kafka.Ksql.Linq.csproj
@@ -30,6 +30,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
                 <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.0.0" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />

--- a/src/Kafka.Ksql.Linq.csproj
+++ b/src/Kafka.Ksql.Linq.csproj
@@ -28,8 +28,9 @@
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.17" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.0.0" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Application;
 using Kafka.Ksql.Linq.Core.Context;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Application;

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -49,4 +49,17 @@ public class KsqlContextBuilderTests
         Assert.Equal(System.TimeSpan.FromSeconds(5), options.SchemaRegistrationTimeout);
         Assert.True(options.EnableDebugLogging);
     }
+
+    [Fact]
+    public void UseConfiguration_SetsOptions()
+    {
+        var config = new Microsoft.Extensions.Configuration.ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var options = KsqlContextBuilder.Create()
+            .UseConfiguration(config)
+            .UseSchemaRegistry("http://localhost:8081")
+            .Build();
+
+        Assert.Equal(config, options.Configuration);
+    }
 }

--- a/tests/Core/LoggerConfigurationTests.cs
+++ b/tests/Core/LoggerConfigurationTests.cs
@@ -1,0 +1,28 @@
+using Kafka.Ksql.Linq.Core.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Core;
+
+public class LoggerConfigurationTests
+{
+    [Fact]
+    public void CreateLoggerFactory_FromConfiguration_RespectsNamespaceLevels()
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.logging.json")
+            .Build();
+
+        using var factory = config.CreateLoggerFactory();
+
+        var serLogger = factory.CreateLogger("Kafka.Ksql.Linq.Serialization.Sample");
+        var msgLogger = factory.CreateLogger("Kafka.Ksql.Linq.Messaging.Sample");
+        var coreLogger = factory.CreateLogger("Kafka.Ksql.Linq.Core.Sample");
+
+        Assert.True(serLogger.IsEnabled(LogLevel.Debug));
+        Assert.False(msgLogger.IsEnabled(LogLevel.Information));
+        Assert.True(msgLogger.IsEnabled(LogLevel.Warning));
+        Assert.True(coreLogger.IsEnabled(LogLevel.Information));
+    }
+}

--- a/tests/Kafka.Ksql.Linq.Tests.csproj
+++ b/tests/Kafka.Ksql.Linq.Tests.csproj
@@ -16,5 +16,8 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <None Include="appsettings.logging.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/tests/Kafka.Ksql.Linq.Tests.csproj
+++ b/tests/Kafka.Ksql.Linq.Tests.csproj
@@ -15,8 +15,9 @@
     <Compile Include="../samples/topic_fluent_api_extension/ManagedTopicExtensions.cs" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <None Include="appsettings.logging.json">
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+  <None Include="appsettings.logging.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tests/appsettings.logging.json
+++ b/tests/appsettings.logging.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Kafka.Ksql.Linq.Serialization": "Debug",
+      "Kafka.Ksql.Linq.Messaging": "Warning",
+      "Kafka.Ksql.Linq.Core": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enable configuration-based logger factory
- expose helper to create LoggerFactory from appsettings
- add UseConfiguration helper on builder
- add tests verifying builder configuration
- document new APIs and tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4060bb4883279a61cefd3f83c03a