### PR TITLE
Refactor entity type detection

### DIFF
--- a/src/Core/Abstractions/EntityModel.cs
+++ b/src/Core/Abstractions/EntityModel.cs
@@ -1,6 +1,5 @@
 using Kafka.Ksql.Linq.Query.Abstractions;
 using System;
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
 
 namespace Kafka.Ksql.Linq.Core.Abstractions;
@@ -27,7 +26,7 @@ public class EntityModel
             if (streamAttribute != null)
                 return StreamTableType.Stream;
 
-            var tableAttribute = EntityType.GetCustomAttribute<TableAttribute>();
+            var tableAttribute = EntityType.GetCustomAttribute<KsqlTableAttribute>();
             if (tableAttribute != null)
                 return StreamTableType.Table;
 

--- a/src/Query/Schema/SchemaRegistry.cs
+++ b/src/Query/Schema/SchemaRegistry.cs
@@ -231,13 +231,6 @@ internal class SchemaRegistry : IDisposable
             return Kafka.Ksql.Linq.Query.Abstractions.StreamTableType.Table;
         }
 
-        // 2. EF Core TableAttribute の存在確認
-        if (entityType.GetCustomAttribute<System.ComponentModel.DataAnnotations.Schema.TableAttribute>() != null)
-        {
-            _logger.LogDebug("Entity {EntityType} has EF Core [Table] attribute, defaulting to TABLE", entityType.Name);
-            return Kafka.Ksql.Linq.Query.Abstractions.StreamTableType.Table;
-        }
-
         // 3. キープロパティの有無で判定
         if (entityModel.KeyProperties != null && entityModel.KeyProperties.Length > 0)
         {

--- a/tests/Query/Schema/SchemaRegistryTests.cs
+++ b/tests/Query/Schema/SchemaRegistryTests.cs
@@ -30,6 +30,12 @@ public class SchemaRegistryTests
         public int Id { get; set; }
     }
 
+    [KsqlTable]
+    private class TableEntity
+    {
+        public int Id { get; set; }
+    }
+
     [Fact]
     public async Task RegisterSchemaAsync_UsesCreateTableWhenKeysPresent()
     {
@@ -61,6 +67,22 @@ public class SchemaRegistryTests
         await registry.RegisterSchemaAsync<StreamEntity>(model);
         Assert.Contains("CREATE STREAM", executor.DdlQueries.First());
         Assert.True(registry.IsRegistered(typeof(StreamEntity)));
+    }
+
+    [Fact]
+    public async Task RegisterSchemaAsync_TableAttribute_UsesCreateTable()
+    {
+        var executor = new FakeExecutor();
+        var ddl = new DDLQueryGenerator(new NullLoggerFactory());
+        var registry = new SchemaRegistry(executor, ddl, new NullLoggerFactory());
+        var model = new EntityModel
+        {
+            EntityType = typeof(TableEntity),
+            AllProperties = typeof(TableEntity).GetProperties()
+        };
+        await registry.RegisterSchemaAsync<TableEntity>(model);
+        Assert.Contains("CREATE TABLE", executor.DdlQueries.First());
+        Assert.True(registry.IsRegistered(typeof(TableEntity)));
     }
     [Fact]
     public async Task UnregisterSchemaAsync_RemovesRegistration()


### PR DESCRIPTION
## Summary
- remove EF Core `[Table]` attribute fallback
- detect table entities via `KsqlTableAttribute` only

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f67ec3f888327b462449a1e963b04