### PR TITLE
Add manual DLQ sending

### DIFF
--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Kafka.Ksql.Linq.Messaging.Producers;
+using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Application;
 using System;

--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -1,0 +1,78 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Context;
+using Kafka.Ksql.Linq.Messaging.Abstractions;
+using Kafka.Ksql.Linq.Messaging.Producers.Core;
+using Kafka.Ksql.Linq.Messaging.Producers;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Application;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Application;
+
+public class KsqlContextDlqSendTests
+{
+    private class StubProducer<T> : IKafkaProducer<T> where T : class
+    {
+        public bool Sent;
+        public string TopicName => "t";
+        public Task<KafkaDeliveryResult> SendAsync(T message, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+        {
+            Sent = true;
+            return Task.FromResult(new KafkaDeliveryResult());
+        }
+        public Task<KafkaBatchDeliveryResult> SendBatchAsync(IEnumerable<T> messages, KafkaMessageContext? context = null, CancellationToken cancellationToken = default)
+        {
+            Sent = true;
+            return Task.FromResult(new KafkaBatchDeliveryResult());
+        }
+        public Task FlushAsync(TimeSpan timeout) => Task.CompletedTask;
+        public void Dispose() { }
+    }
+
+    private class TestContext : KsqlContext
+    {
+        public TestContext() : base() { }
+
+        protected override bool SkipSchemaRegistration => true;
+
+        public void SetProducerManager(KafkaProducerManager manager)
+        {
+            typeof(KsqlContext).GetField("_producerManager", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, manager);
+        }
+
+        public void SetDlqProducer(DlqProducer producer)
+        {
+            typeof(KsqlContext).GetField("_dlqProducer", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, producer);
+        }
+    }
+
+    private class Sample { public int Id { get; set; } }
+
+    [Fact]
+    public async Task SendToDlqAsync_UsesDlqProducer()
+    {
+        var ctx = new TestContext();
+        var options = new KsqlDslOptions();
+        var manager = new KafkaProducerManager(Microsoft.Extensions.Options.Options.Create(options), null);
+        ctx.SetProducerManager(manager);
+
+        var stub = new StubProducer<DlqEnvelope>();
+        var dict = (ConcurrentDictionary<(System.Type,string), object>)
+            typeof(KafkaProducerManager).GetField("_topicProducers", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(manager)!;
+        dict[(typeof(DlqEnvelope), options.DlqTopicName)] = stub;
+
+        var dlq = new DlqProducer(manager, new DlqOptions { TopicName = options.DlqTopicName });
+        dlq.InitializeAsync().GetAwaiter().GetResult();
+        ctx.SetDlqProducer(dlq);
+
+        await ctx.SendToDlqAsync(new Sample(), new System.Exception("err"));
+
+        Assert.True(stub.Sent);
+    }
+}

--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Kafka.Ksql.Linq.Messaging.Producers;
+using KsqlDsl.Messaging.Models;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Application;

--- a/tests/Application/KsqlContextDlqSendTests.cs
+++ b/tests/Application/KsqlContextDlqSendTests.cs
@@ -5,6 +5,7 @@ using Kafka.Ksql.Linq.Messaging.Producers.Core;
 using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Application;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/Application/KsqlContextTests.cs
+++ b/tests/Application/KsqlContextTests.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Context;
 using Kafka.Ksql.Linq.Messaging.Consumers;
+using Kafka.Ksql.Linq.Messaging.Producers;
 using Kafka.Ksql.Linq.Application;
 using System;
 using Xunit;
@@ -22,6 +23,7 @@ public class KsqlContextTests
 
         public KafkaProducerManager CallGetProducerManager() => base.GetProducerManager();
         public KafkaConsumerManager CallGetConsumerManager() => base.GetConsumerManager();
+        public DlqProducer CallGetDlqProducer() => base.GetDlqProducer();
     }
 
     [Fact]
@@ -53,5 +55,12 @@ public class KsqlContextTests
     {
         var ctx = new TestContext();
         ctx.Dispose();
+    }
+
+    [Fact]
+    public void GetDlqProducer_ReturnsInstance()
+    {
+        var ctx = new TestContext();
+        Assert.NotNull(ctx.CallGetDlqProducer());
     }
 }


### PR DESCRIPTION
## Summary
- expose DLQ producer from `KsqlContext`
- add `SendToDlqAsync` for manual DLQ sending
- helper to get topic name by type
- tests for DLQ producer access and manual DLQ send

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f73beebe883278d1d54ecb29ec3d8