### PR TITLE
Remove obsolete debug mode API

### DIFF
--- a/src/Application/KsqlContextBuilder.cs
+++ b/src/Application/KsqlContextBuilder.cs
@@ -58,11 +58,6 @@ public class KsqlContextBuilder
         return this;
     }
 
-    public KsqlContextBuilder EnableDebugMode(bool enable = true)
-    {
-        _options.EnableDebugMode(enable);
-        return this;
-    }
 
     public KsqlContextOptions Build()
     {

--- a/src/Application/KsqlContextOptions.cs
+++ b/src/Application/KsqlContextOptions.cs
@@ -7,7 +7,6 @@ public class KsqlContextOptions
     public ISchemaRegistryClient SchemaRegistryClient { get; set; } = null!;
     public ILoggerFactory? LoggerFactory { get; set; }
     public Microsoft.Extensions.Configuration.IConfiguration? Configuration { get; set; }
-    public bool EnableDebugLogging { get; set; } = false;
     public bool AutoRegisterSchemas { get; set; } = true;
     public bool EnableCachePreWarming { get; set; } = true;
     public bool FailOnInitializationErrors { get; set; } = true;

--- a/src/Application/KsqlContextOptionsExtensions.cs
+++ b/src/Application/KsqlContextOptionsExtensions.cs
@@ -50,11 +50,4 @@ public static class KsqlContextOptionsExtensions
         return options;
     }
 
-    public static KsqlContextOptions EnableDebugMode(
-        this KsqlContextOptions options,
-        bool enable = true)
-    {
-        options.EnableDebugLogging = enable;
-        return options;
-    }
 }

--- a/tests/Application/KsqlContextBuilderTests.cs
+++ b/tests/Application/KsqlContextBuilderTests.cs
@@ -39,8 +39,7 @@ public class KsqlContextBuilderTests
             .UseSchemaRegistry("http://localhost:8081")
             .EnableLogging(factory)
             .ConfigureValidation(autoRegister: false, failOnErrors: false, enablePreWarming: false)
-            .WithTimeouts(System.TimeSpan.FromSeconds(5))
-            .EnableDebugMode(true);
+            .WithTimeouts(System.TimeSpan.FromSeconds(5));
         var options = builder.Build();
         Assert.NotNull(options.SchemaRegistryClient);
         Assert.Equal(factory, options.LoggerFactory);
@@ -48,7 +47,6 @@ public class KsqlContextBuilderTests
         Assert.False(options.FailOnInitializationErrors);
         Assert.False(options.EnableCachePreWarming);
         Assert.Equal(System.TimeSpan.FromSeconds(5), options.SchemaRegistrationTimeout);
-        Assert.True(options.EnableDebugLogging);
     }
 
     [Fact]

--- a/tests/Application/KsqlContextOptionsExtensionsTests.cs
+++ b/tests/Application/KsqlContextOptionsExtensionsTests.cs
@@ -51,11 +51,4 @@ public class KsqlContextOptionsExtensionsTests
         Assert.Equal(ts, options.SchemaRegistrationTimeout);
     }
 
-    [Fact]
-    public void EnableDebugMode_SetsFlag()
-    {
-        var options = new KsqlContextOptions();
-        options.EnableDebugMode(true);
-        Assert.True(options.EnableDebugLogging);
-    }
 }


### PR DESCRIPTION
## Summary
- drop `EnableDebugMode` API and related option
- update builder and options extensions
- clean up tests for removed API

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f92328e488327bd3c730b51fec02d