### PR TITLE
Remove obsolete GetResults method

### DIFF
--- a/docs/api_public_methods.md
+++ b/docs/api_public_methods.md
@@ -397,7 +397,6 @@
 - `public EntityModel GetEntityModel() => _entityModel`
 - `public EventSet<T> WithRetry(int maxRetries, TimeSpan? retryInterval = null)`
 - `public EventSet<TResult> Map<TResult>(Func<T, TResult> mapper) where TResult : class`
-- `public IEnumerable<T> GetResults()`
 - `public IKsqlContext GetContext() => _context`
 - `public MappedEventSet(List<T> mappedItems, IKsqlContext context, EntityModel originalEntityModel, IErrorSink? errorSink = null)`
 - `public abstract IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)`

--- a/src/EventSet.cs
+++ b/src/EventSet.cs
@@ -443,13 +443,6 @@ public abstract class EventSet<T> : IEntitySet<T> where T : class
         };
     }
 
-    /// <summary>
-    /// EventSetの結果を取得します
-    /// </summary>
-    public IEnumerable<T> GetResults()
-    {
-        return ToListAsync().GetAwaiter().GetResult();
-    }
 }
 internal class MappedEventSet<T> : EventSet<T> where T : class
 {


### PR DESCRIPTION
## Summary
- delete `EventSet<T>.GetResults()` method
- drop references to `GetResults` from API docs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f936acd4083279e2875af4a8c044d