### PR TITLE
Remove OnErrorWithMetrics feature

### DIFF
--- a/docs/api_public_methods.md
+++ b/docs/api_public_methods.md
@@ -384,7 +384,6 @@
 ### ErrorHandlingExtensions
 
 - `public static EventSet<T> OnError<T>(this EventSet<T> eventSet,`
-- `public static EventSet<T> OnErrorWithMetrics<T>(this EventSet<T> eventSet,`
 - `public static EventSet<T> WithRetryWhen<T>(this EventSet<T> eventSet,`
 
 ### ErrorHandlingPolicy

--- a/src/Core/Abstractions/ErrorHandlingExtensions.cs
+++ b/src/Core/Abstractions/ErrorHandlingExtensions.cs
@@ -52,31 +52,4 @@ public static class ErrorHandlingExtensions
         return eventSet.WithErrorPolicy(policy);
     }
 
-    /// <summary>
-    /// エラーメトリクス収集付きエラーハンドリング
-    /// </summary>
-    public static EventSet<T> OnErrorWithMetrics<T>(this EventSet<T> eventSet,
-        ErrorAction errorAction,
-        Action<ErrorMetrics>? metricsCallback = null) where T : class
-    {
-        var policy = new ErrorHandlingPolicy
-        {
-            Action = errorAction,
-            MetricsCallback = metricsCallback
-        };
-
-        return eventSet.WithErrorPolicy(policy);
-    }
-}
-/// <summary>
-/// エラーメトリクス情報
-/// </summary>
-public class ErrorMetrics
-{
-    public string EntityType { get; set; } = string.Empty;
-    public string ErrorPhase { get; set; } = string.Empty;
-    public Exception Exception { get; set; } = default!;
-    public int AttemptCount { get; set; }
-    public TimeSpan TotalDuration { get; set; }
-    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
 }

--- a/src/Core/Abstractions/ErrorHandlingPolicy.cs
+++ b/src/Core/Abstractions/ErrorHandlingPolicy.cs
@@ -17,10 +17,6 @@ public class ErrorHandlingPolicy
     /// </summary>
     public Predicate<Exception>? RetryCondition { get; set; }
 
-    /// <summary>
-    /// エラーメトリクス収集コールバック
-    /// </summary>
-    public Action<ErrorMetrics>? MetricsCallback { get; set; }
 
     /// <summary>
     /// エラー発生時の追加ログ情報


### PR DESCRIPTION
## Summary
- remove deprecated `OnErrorWithMetrics` extension and `ErrorMetrics` type
- drop related `MetricsCallback` property
- update API docs

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f9484303883279f8345093fb9e7ee