### PR TITLE
Implement window final topic naming

### DIFF
--- a/src/Window/Finalization/WindowConfiguration.cs
+++ b/src/Window/Finalization/WindowConfiguration.cs
@@ -11,4 +11,9 @@ public class WindowConfiguration<T> where T : class
     public int RetentionHours { get; set; } = 24;
     public Func<List<T>, object> AggregationFunc { get; set; } = events => events.Count;
     public IKafkaProducer FinalTopicProducer { get; set; } = null!;
+
+    public string GetFinalTopicName(int windowMinutes)
+    {
+        return $"{TopicName}_window_{windowMinutes}_final";
+    }
 }

--- a/src/Window/Finalization/WindowFinalConsumer.cs
+++ b/src/Window/Finalization/WindowFinalConsumer.cs
@@ -28,11 +28,13 @@ internal class WindowFinalConsumer : IDisposable
     /// 確定足データを購読してRocksDBに保存
     /// </summary>
     public async Task SubscribeToFinalizedWindows(string topicName,
+        int windowMinutes,
         Func<WindowFinalMessage, Task> messageHandler)
     {
-        _logger.LogInformation("Starting subscription to finalized windows: {Topic} → RocksDB", topicName);
+        _logger.LogInformation("Starting subscription to finalized windows: {Topic}({Window}) → RocksDB",
+            topicName, windowMinutes);
 
-        var finalTopic = $"{topicName}_window_final";
+        var finalTopic = $"{topicName}_window_{windowMinutes}_final";
 
         // Kafka Consumer setup for final topic
         // await foreach (var message in kafkaConsumer.ConsumeAsync())

--- a/src/Window/Finalization/WindowProcessor.cs
+++ b/src/Window/Finalization/WindowProcessor.cs
@@ -150,13 +150,15 @@ internal class WindowProcessor<T> : WindowProcessor where T : class
 
         // KafkaProducerを使用して送信
         // 重複送信対策：同一キーの場合は最初に到着したものが有効
+        var finalTopic = _config.GetFinalTopicName(windowState.WindowMinutes);
+
         await _config.FinalTopicProducer.SendAsync(
-            topic: $"{_config.TopicName}_window_final",
+            topic: finalTopic,
             key: windowKey,
             value: finalTopicMessage);
 
         _logger.LogDebug("Sent finalized window to topic: {Topic}, Key: {Key}",
-            $"{_config.TopicName}_window_final", windowKey);
+            finalTopic, windowKey);
     }
 
     /// <summary>

--- a/tests/Window/Finalization/WindowFinalizationManagerTests.cs
+++ b/tests/Window/Finalization/WindowFinalizationManagerTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Kafka.Ksql.Linq.Window.Finalization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Window.Finalization;
+
+public class WindowFinalizationManagerTests
+{
+    private class FakeProducer : IKafkaProducer
+    {
+        public List<(string Topic,string Key,object Value)> Sent { get; } = new();
+        public Task SendAsync(string topic, string key, object value)
+        {
+            Sent.Add((topic,key,value));
+            return Task.CompletedTask;
+        }
+        public void Dispose() { }
+    }
+
+    private class TestEntity
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public async Task FinalTopicName_IncludesWindowSize()
+    {
+        var producer = new FakeProducer();
+        var config = new WindowConfiguration<TestEntity>
+        {
+            TopicName = "orders",
+            Windows = new[] { 5 },
+            GracePeriod = TimeSpan.Zero,
+            FinalTopicProducer = producer,
+            AggregationFunc = events => events.Count
+        };
+        var processor = new WindowProcessor<TestEntity>(config, NullLogger.Instance);
+
+        var now = DateTime.UtcNow;
+        processor.AddToWindow(new TestEntity { Id = 1 }, now);
+
+        await processor.ProcessFinalization(now.AddMinutes(6));
+
+        Assert.Contains(producer.Sent, x => x.Topic == "orders_window_5_final");
+    }
+}


### PR DESCRIPTION
## Summary
- add helper to get per-window final topic name
- emit finalized data to `{topic}_window_{minutes}_final` topics
- update consumer API for window duration
- add regression test for final topic naming

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe4f585308327aa2913d7d6941bc2