### PR TITLE
Simplify hello world example

### DIFF
--- a/examples/hello-world/HelloWorld.csproj
+++ b/examples/hello-world/HelloWorld.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/hello-world/Program.cs
+++ b/examples/hello-world/Program.cs
@@ -1,0 +1,59 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+[Topic("hello-world")]
+public class HelloMessage
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime CreatedAt { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+}
+
+public class HelloKafkaContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<HelloMessage>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<HelloKafkaContext>();
+
+        var message = new HelloMessage
+        {
+            Id = Random.Shared.Next(),
+            CreatedAt = DateTime.UtcNow,
+            Text = "Hello World"
+        };
+
+        await context.Set<HelloMessage>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<HelloMessage>().ForEachAsync(m =>
+        {
+            Console.WriteLine($"Received: {m.Text}");
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,30 @@
+# Hello World Example
+
+This sample demonstrates the minimal workflow of **Kafka.Ksql.Linq**.
+`Program.cs` contains all logic: it defines a simple POCO entity,
+registers it in a context, sends one message with `AddAsync`, waits briefly
+for the message to be published, and then consumes it with `ForEachAsync`.
+
+## Prerequisites
+
+- .NET 8 SDK
+- Docker (for Kafka and Schema Registry)
+
+## Setup
+
+1. Start the local Kafka stack:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run the example:
+   ```bash
+   dotnet run --project .
+   ```
+
+## Design Document References
+
+- [POCO構造と属性の説明](../../docs/oss_design_combined.md#3-poco属性ベースdsl設計ルール（fluent-apiの排除方針）)
+- [スキーマ登録の説明](../../docs/oss_design_combined.md#4-スキーマ構築と初期化手順onmodelcreating)
+- [送信操作](../../docs/oss_design_combined.md#5-プロデュース操作)
+- [受信操作](../../docs/oss_design_combined.md#6-コンシューム操作、（リトライ、エラー、dlq、commitの誤解）)
+- [ログ設定](../../docs/oss_design_combined.md#8ロギングとクエリ可視化)

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -8,7 +8,7 @@ for the message to be published, and then consumes it with `ForEachAsync`.
 ## Prerequisites
 
 - .NET 8 SDK
-- Docker (for Kafka and Schema Registry)
+- Docker (for Kafka and ksqlDB)
 
 ## Setup
 

--- a/examples/hello-world/appsettings.json
+++ b/examples/hello-world/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "hello-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/hello-world/docker-compose.yml
+++ b/examples/hello-world/docker-compose.yml
@@ -1,32 +1,55 @@
 version: '3.7'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.5.0
+    image: confluentinc/cp-zookeeper:7.4.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     ports:
-      - '2181:2181'
+      - "2181:2181"
 
   kafka:
-    image: confluentinc/cp-kafka:7.5.0
+    image: confluentinc/cp-kafka:7.4.3
     depends_on:
       - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-    ports:
-      - '9092:9092'
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.5.0
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
     depends_on:
-      - kafka
-    environment:
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
-      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8085
+      kafka:
+        condition: service_healthy
     ports:
-      - '8085:8085'
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true

--- a/examples/hello-world/docker-compose.yml
+++ b/examples/hello-world/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - '2181:2181'
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    ports:
+      - '9092:9092'
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.5.0
+    depends_on:
+      - kafka
+    environment:
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:9092
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8085
+    ports:
+      - '8085:8085'


### PR DESCRIPTION
## Summary
- consolidate producer and consumer plus message and context into `Program.cs`
- add short delay after sending to allow consumption
- update README to mention the delay
- remove separate `HelloMessage.cs` and `HelloKafkaContext.cs`

## Testing
- `dotnet build examples/hello-world/HelloWorld.csproj -c Release` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffbf1c72c8327b338374e853ffe13