### PR TITLE
Add configuration logging sample

### DIFF
--- a/examples/configuration/Program.cs
+++ b/examples/configuration/Program.cs
@@ -1,0 +1,60 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+[Topic("hello-world")]
+public class HelloMessage
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime CreatedAt { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+}
+
+public class HelloKafkaContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<HelloMessage>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            // replace with `appsettings.Development.json` or `appsettings.Production.json`
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<HelloKafkaContext>();
+
+        var message = new HelloMessage
+        {
+            Id = Random.Shared.Next(),
+            CreatedAt = DateTime.UtcNow,
+            Text = "Hello World"
+        };
+
+        await context.Set<HelloMessage>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<HelloMessage>().ForEachAsync(m =>
+        {
+            Console.WriteLine($"Received: {m.Text}");
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -1,0 +1,27 @@
+# Configuration Example
+
+This sample demonstrates how to switch logging output between development and production environments using **Kafka.Ksql.Linq**.
+The default `appsettings.json` is tuned for debugging with `LogLevel:Debug`.
+`Program.cs` is copied from the Hello World example. `appsettings.Development.json` enables verbose logging for development, while
+`appsettings.Production.json` suppresses most output for a quieter runtime. Replace the file referenced in `Program.cs` as needed before running.
+`docker-compose.yml` provides the required Kafka and ksqlDB services.
+
+## Prerequisites
+
+- .NET 8 SDK
+- Docker (for Kafka and ksqlDB)
+
+## Setup
+
+1. Start the local Kafka stack:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run your application with the desired configuration, for example:
+   ```bash
+   dotnet run --no-build --environment Development
+   ```
+
+## Design Document Reference
+
+- [ロギングとクエリ可視化](../../docs/oss_design_combined.md#8ロギングとクエリ可視化)

--- a/examples/configuration/appsettings.Development.json
+++ b/examples/configuration/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Kafka.Ksql.Linq.Serialization": "Debug",
+      "Kafka.Ksql.Linq.Messaging": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  }
+}

--- a/examples/configuration/appsettings.Production.json
+++ b/examples/configuration/appsettings.Production.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Kafka.Ksql.Linq.Serialization": "Warning",
+      "Kafka.Ksql.Linq.Messaging": "Warning",
+      "Kafka.Ksql.Linq.Query": "None"
+    }
+  }
+}

--- a/examples/configuration/appsettings.json
+++ b/examples/configuration/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "config-sample-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/configuration/docker-compose.yml
+++ b/examples/configuration/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true


### PR DESCRIPTION
## Summary
- showcase environment-based log settings for Kafka.Ksql.Linq
- share docker compose file for local Kafka stack
- bring Hello World `Program.cs` and note switching `appsettings` files
- include a default appsettings.json configured for debug

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600cf485908327af92cda5c7018f45