### PR TITLE
Fix finalized window topic name

### DIFF
--- a/src/StateStore/Extensions/ReadCachedWindowSet.cs
+++ b/src/StateStore/Extensions/ReadCachedWindowSet.cs
@@ -48,7 +48,11 @@ internal class ReadCachedWindowSet<T> : Kafka.Ksql.Linq.StateStore.IWindowedEnti
     }
 
     public string GetTopicName()
-        => $"{_baseSet.GetTopicName()}_window_{WindowMinutes}_final";
+    {
+        var model = _baseSet.GetEntityModel();
+        var baseName = model.TopicAttribute?.TopicName ?? _baseSet.GetTopicName();
+        return $"{baseName}_window_{WindowMinutes}_final";
+    }
 
     public EntityModel GetEntityModel() => _baseSet.GetEntityModel();
 


### PR DESCRIPTION
## Summary
- ensure `UseFinalized()` returns a windowed set with topic name based on `TopicAttribute`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c23434d48327bfacfdd359fb8820