### PR TITLE
Add additional unit tests for builders

### DIFF
--- a/tests/PrivateAccessor.cs
+++ b/tests/PrivateAccessor.cs
@@ -16,7 +16,8 @@ internal static class PrivateAccessor
     {
         var startType = target as Type ?? target.GetType();
         var type = startType;
-        var flags = BindingFlags.NonPublic | (target is Type ? BindingFlags.Static : BindingFlags.Instance);
+        var flags = BindingFlags.NonPublic | BindingFlags.Public |
+                    (target is Type ? BindingFlags.Static : BindingFlags.Instance);
         MethodInfo? method = null;
         while (type != null)
         {

--- a/tests/Query/Builders/HavingBuilderTests.cs
+++ b/tests/Query/Builders/HavingBuilderTests.cs
@@ -66,4 +66,16 @@ public class HavingBuilderTests
             InvokePrivate<string>(visitorType, "GetSqlOperator", new[] { typeof(ExpressionType) }, null, ExpressionType.ArrayIndex));
         Assert.IsType<NotSupportedException>(ex.InnerException);
     }
+
+    [Theory]
+    [InlineData("SUM", true)]
+    [InlineData("COUNT", true)]
+    [InlineData("COLLECTLIST", true)]
+    [InlineData("UNKNOWN", false)]
+    public void IsAggregateFunction_DetectsAggregateMethods(string name, bool expected)
+    {
+        var visitorType = typeof(HavingBuilder).GetNestedType("HavingExpressionVisitor", BindingFlags.NonPublic)!;
+        var result = InvokePrivate<bool>(visitorType, "IsAggregateFunction", new[] { typeof(string) }, null, name);
+        Assert.Equal(expected, result);
+    }
 }

--- a/tests/Query/Builders/JoinBuilderTests.cs
+++ b/tests/Query/Builders/JoinBuilderTests.cs
@@ -110,5 +110,16 @@ public class JoinBuilderTests
         var result = InvokePrivate<MethodCallExpression?>(builder, "FindJoinCall", new[] { typeof(Expression) }, null, invoke);
         Assert.NotNull(result);
     }
+
+    [Fact]
+    public void BuildJoinQuery_GeneratesJoinStatement()
+    {
+        IQueryable<TestEntity> outer = new List<TestEntity>().AsQueryable();
+        IQueryable<ChildEntity> inner = new List<ChildEntity>().AsQueryable();
+        var joinExpr = outer.Join(inner, o => o.Id, c => c.ParentId, (o, c) => new { o.Id, c.Name }).Expression as MethodCallExpression;
+        var builder = new JoinBuilder();
+        var sql = InvokePrivate<string>(builder, "BuildJoinQuery", new[] { typeof(MethodCallExpression) }, null, joinExpr!);
+        Assert.StartsWith("SELECT o.Id, c.Name FROM TestEntity o JOIN ChildEntity c ON o.Id = c.ParentId", sql);
+    }
 }
 

--- a/tests/Query/Builders/ProjectionBuilderTests.cs
+++ b/tests/Query/Builders/ProjectionBuilderTests.cs
@@ -54,4 +54,22 @@ public class ProjectionBuilderTests
             InvokePrivate<string>(visitorType, "GetSqlOperator", new[] { typeof(ExpressionType) }, null, ExpressionType.ArrayIndex));
         Assert.IsType<NotSupportedException>(ex.InnerException);
     }
+
+    [Fact]
+    public void Build_CountWithoutSelector_GeneratesCountAll()
+    {
+        Expression<Func<IGrouping<int, TestEntity>, object>> expr = g => g.Count();
+        var builder = new ProjectionBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("SELECT COUNT(*)", result);
+    }
+
+    [Fact]
+    public void Build_SubstringWithLength_GeneratesSubstringFunction()
+    {
+        Expression<Func<TestEntity, object>> expr = e => e.Name.Substring(1, 3);
+        var builder = new ProjectionBuilder();
+        var result = builder.Build(expr.Body);
+        Assert.Equal("SELECT SUBSTRING(Name, 1, 3)", result);
+    }
 }

--- a/tests/Query/Builders/ProjectionBuilderTests.cs
+++ b/tests/Query/Builders/ProjectionBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Kafka.Ksql.Linq.Query.Builders;

--- a/tests/Query/Builders/WindowBuilderTests.cs
+++ b/tests/Query/Builders/WindowBuilderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using Kafka.Ksql.Linq.Query.Builders;
 using Xunit;
 
@@ -21,5 +22,16 @@ public class WindowBuilderTests
     {
         var builder = new WindowBuilder();
         Assert.Throws<ArgumentNullException>(() => builder.Build(null!));
+    }
+
+    [Fact]
+    public void VisitMethodCall_BuildsTumblingWindowClause()
+    {
+        Expression<Func<WindowDef, WindowDef>> expr = w => w.TumblingWindow().Size(TimeSpan.FromSeconds(30)).EmitFinal();
+        var visitorType = typeof(WindowBuilder).GetNestedType("WindowExpressionVisitor", BindingFlags.NonPublic)!;
+        var visitor = Activator.CreateInstance(visitorType)!;
+        InvokePrivate<object>(visitor, "Visit", new[] { typeof(Expression) }, null, expr.Body);
+        var result = (string)visitorType.GetMethod("BuildWindowClause")!.Invoke(visitor, null)!;
+        Assert.Equal("WINDOW TUMBLING (SIZE 30 SECONDS) EMIT FINAL", result);
     }
 }

--- a/tests/Query/Builders/WindowBuilderTests.cs
+++ b/tests/Query/Builders/WindowBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Kafka.Ksql.Linq.Query.Builders;
 using Xunit;
+using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 

--- a/tests/Query/Pipeline/WindowDDLExtensionsTests.cs
+++ b/tests/Query/Pipeline/WindowDDLExtensionsTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq;
+using Xunit;
+using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
+
+public class WindowDDLExtensionsTests
+{
+    private class Sample
+    {
+        public bool Flag { get; set; }
+        public DateTime Created { get; set; }
+    }
+
+    [Theory]
+    [InlineData(nameof(Sample.Flag), "boolean")]
+    [InlineData(nameof(Sample.Created), "long")]
+    public void MapPropertyTypeToAvroType_ReturnsExpected(string propName, string expected)
+    {
+        var prop = typeof(Sample).GetProperty(propName)!;
+        var result = InvokePrivate<string>(typeof(WindowDDLExtensions), "MapPropertyTypeToAvroType", new[] { typeof(PropertyInfo) }, null, prop);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void GenerateAggregationFunction_ReturnsWindowFunctions()
+    {
+        var visitor = new WindowSelectExpressionVisitor();
+        var param = Expression.Parameter(typeof(IGrouping<int, TestEntity>), "g");
+        var startCall = Expression.Call(typeof(WindowInfoExtensions).GetMethod("WindowStart")!.MakeGenericMethod(typeof(TestEntity), typeof(int)), param);
+        var result = InvokePrivate<string>(visitor, "GenerateAggregationFunction", new[] { typeof(MethodCallExpression) }, null, startCall);
+        Assert.Equal("WINDOWSTART", result);
+
+        var lambdaParam = Expression.Parameter(typeof(TestEntity), "x");
+        var lambda = Expression.Lambda(Expression.Property(lambdaParam, nameof(TestEntity.Id)), lambdaParam);
+        var sumMethod = typeof(Enumerable).GetMethods().First(m => m.Name == "Sum" && m.GetParameters().Length == 2).MakeGenericMethod(typeof(TestEntity));
+        var sumCall = Expression.Call(sumMethod, param, lambda);
+        result = InvokePrivate<string>(visitor, "GenerateAggregationFunction", new[] { typeof(MethodCallExpression) }, null, sumCall);
+        Assert.Equal("SUM(ID)", result);
+
+        var countMethod = typeof(Enumerable).GetMethods().First(m => m.Name == "Count" && m.GetParameters().Length == 1).MakeGenericMethod(typeof(TestEntity));
+        var countCall = Expression.Call(countMethod, param);
+        result = InvokePrivate<string>(visitor, "GenerateAggregationFunction", new[] { typeof(MethodCallExpression) }, null, countCall);
+        Assert.Equal("COUNT(*)", result);
+    }
+}

--- a/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
+++ b/tests/Serialization/AvroSchemaBuilderDetailedTests.cs
@@ -83,6 +83,10 @@ public class AvroSchemaBuilderDetailedTests
         obj = InvokePrivate<object>(builder, "GetBasicAvroType", new[] { typeof(PropertyInfo), typeof(Type) }, null, date, typeof(DateTime));
         json = JsonSerializer.Serialize(obj);
         Assert.Contains("date", json);
+        var guid = typeof(SampleEntity).GetProperty(nameof(SampleEntity.GuidKey))!;
+        obj = InvokePrivate<object>(builder, "GetBasicAvroType", new[] { typeof(PropertyInfo), typeof(Type) }, null, guid, typeof(Guid));
+        json = JsonSerializer.Serialize(obj);
+        Assert.Contains("uuid", json);
     }
 
     [Fact]

--- a/tests/Serialization/UnifiedSchemaGeneratorTests.cs
+++ b/tests/Serialization/UnifiedSchemaGeneratorTests.cs
@@ -92,6 +92,10 @@ public class UnifiedSchemaGeneratorTests
         avro = InvokePrivate<object>(typeof(UnifiedSchemaGenerator), "GetAvroType", new[] { typeof(PropertyInfo) }, null, dtProp);
         json = JsonSerializer.Serialize(avro);
         Assert.Contains("date", json);
+        var guidProp = typeof(SampleEntity).GetProperty(nameof(SampleEntity.GuidKey))!;
+        avro = InvokePrivate<object>(typeof(UnifiedSchemaGenerator), "GetAvroType", new[] { typeof(PropertyInfo) }, null, guidProp);
+        json = JsonSerializer.Serialize(avro);
+        Assert.Contains("uuid", json);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- improve coverage of HavingBuilder, WindowBuilder, ProjectionBuilder, JoinBuilder
- add tests for WindowDDLExtensions
- extend Avro builder tests
- extend UnifiedSchemaGenerator tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c6db64c0832799be5af3468b8c30