### PR TITLE
Add tests for window and offset DSL helpers

### DIFF
--- a/tests/Extensions/WindowDefExtensionClassesTests.cs
+++ b/tests/Extensions/WindowDefExtensionClassesTests.cs
@@ -2,16 +2,16 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
-using Kafka.Ksql.Linq;
+using Ksql = Kafka.Ksql.Linq;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Extensions;
 
 public class WindowDefExtensionClassesTests
 {
-    private static List<(string Name, object? Value)> GetOperations(WindowDef def)
+    private static List<(string Name, object? Value)> GetOperations(Ksql.WindowDef def)
     {
-        var field = typeof(WindowDef).GetField("Operations", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var field = typeof(Ksql.WindowDef).GetField("Operations", BindingFlags.Instance | BindingFlags.NonPublic)!;
         return (List<(string Name, object? Value)>)field.GetValue(def)!;
     }
 
@@ -19,7 +19,7 @@ public class WindowDefExtensionClassesTests
     public void HoppingWindow_Of_BuildsOperations()
     {
         var ts = TimeSpan.FromMinutes(5);
-        var def = HoppingWindow.Of(ts);
+        var def = Ksql.HoppingWindow.Of(ts);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("HoppingWindow", (object?)null), ("Size", (object?)ts) }, ops);
     }
@@ -27,7 +27,7 @@ public class WindowDefExtensionClassesTests
     [Fact]
     public void HoppingWindow_OfMinutes_BuildsOperations()
     {
-        var def = HoppingWindow.OfMinutes(2);
+        var def = Ksql.HoppingWindow.OfMinutes(2);
         var ts = TimeSpan.FromMinutes(2);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("HoppingWindow", (object?)null), ("Size", (object?)ts) }, ops);
@@ -37,7 +37,7 @@ public class WindowDefExtensionClassesTests
     public void SessionWindow_Of_BuildsOperations()
     {
         var ts = TimeSpan.FromMinutes(7);
-        var def = SessionWindow.Of(ts);
+        var def = Ksql.SessionWindow.Of(ts);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("SessionWindow", (object?)null), ("Gap", (object?)ts) }, ops);
     }
@@ -45,7 +45,7 @@ public class WindowDefExtensionClassesTests
     [Fact]
     public void SessionWindow_OfMinutes_BuildsOperations()
     {
-        var def = SessionWindow.OfMinutes(3);
+        var def = Ksql.SessionWindow.OfMinutes(3);
         var ts = TimeSpan.FromMinutes(3);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("SessionWindow", (object?)null), ("Gap", (object?)ts) }, ops);

--- a/tests/Extensions/WindowDefExtensionClassesTests.cs
+++ b/tests/Extensions/WindowDefExtensionClassesTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
+using Kafka.Ksql.Linq;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Extensions;
+
+public class WindowDefExtensionClassesTests
+{
+    private static List<(string Name, object? Value)> GetOperations(WindowDef def)
+    {
+        var field = typeof(WindowDef).GetField("Operations", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (List<(string Name, object? Value)>)field.GetValue(def)!;
+    }
+
+    [Fact]
+    public void HoppingWindow_Of_BuildsOperations()
+    {
+        var ts = TimeSpan.FromMinutes(5);
+        var def = HoppingWindow.Of(ts);
+        var ops = GetOperations(def);
+        Assert.Equal(new[] { ("HoppingWindow", (object?)null), ("Size", (object?)ts) }, ops);
+    }
+
+    [Fact]
+    public void HoppingWindow_OfMinutes_BuildsOperations()
+    {
+        var def = HoppingWindow.OfMinutes(2);
+        var ts = TimeSpan.FromMinutes(2);
+        var ops = GetOperations(def);
+        Assert.Equal(new[] { ("HoppingWindow", (object?)null), ("Size", (object?)ts) }, ops);
+    }
+
+    [Fact]
+    public void SessionWindow_Of_BuildsOperations()
+    {
+        var ts = TimeSpan.FromMinutes(7);
+        var def = SessionWindow.Of(ts);
+        var ops = GetOperations(def);
+        Assert.Equal(new[] { ("SessionWindow", (object?)null), ("Gap", (object?)ts) }, ops);
+    }
+
+    [Fact]
+    public void SessionWindow_OfMinutes_BuildsOperations()
+    {
+        var def = SessionWindow.OfMinutes(3);
+        var ts = TimeSpan.FromMinutes(3);
+        var ops = GetOperations(def);
+        Assert.Equal(new[] { ("SessionWindow", (object?)null), ("Gap", (object?)ts) }, ops);
+    }
+}

--- a/tests/Extensions/WindowDefExtensionClassesTests.cs
+++ b/tests/Extensions/WindowDefExtensionClassesTests.cs
@@ -2,16 +2,16 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
-using Ksql = Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Extensions;
 
 public class WindowDefExtensionClassesTests
 {
-    private static List<(string Name, object? Value)> GetOperations(Ksql.WindowDef def)
+    private static List<(string Name, object? Value)> GetOperations(global::Kafka.Ksql.Linq.WindowDef def)
     {
-        var field = typeof(Ksql.WindowDef).GetField("Operations", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var field = typeof(global::Kafka.Ksql.Linq.WindowDef).GetField("Operations", BindingFlags.Instance | BindingFlags.NonPublic)!;
         return (List<(string Name, object? Value)>)field.GetValue(def)!;
     }
 
@@ -19,7 +19,7 @@ public class WindowDefExtensionClassesTests
     public void HoppingWindow_Of_BuildsOperations()
     {
         var ts = TimeSpan.FromMinutes(5);
-        var def = Ksql.HoppingWindow.Of(ts);
+        var def = global::Kafka.Ksql.Linq.HoppingWindow.Of(ts);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("HoppingWindow", (object?)null), ("Size", (object?)ts) }, ops);
     }
@@ -27,7 +27,7 @@ public class WindowDefExtensionClassesTests
     [Fact]
     public void HoppingWindow_OfMinutes_BuildsOperations()
     {
-        var def = Ksql.HoppingWindow.OfMinutes(2);
+        var def = global::Kafka.Ksql.Linq.HoppingWindow.OfMinutes(2);
         var ts = TimeSpan.FromMinutes(2);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("HoppingWindow", (object?)null), ("Size", (object?)ts) }, ops);
@@ -37,7 +37,7 @@ public class WindowDefExtensionClassesTests
     public void SessionWindow_Of_BuildsOperations()
     {
         var ts = TimeSpan.FromMinutes(7);
-        var def = Ksql.SessionWindow.Of(ts);
+        var def = global::Kafka.Ksql.Linq.SessionWindow.Of(ts);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("SessionWindow", (object?)null), ("Gap", (object?)ts) }, ops);
     }
@@ -45,7 +45,7 @@ public class WindowDefExtensionClassesTests
     [Fact]
     public void SessionWindow_OfMinutes_BuildsOperations()
     {
-        var def = Ksql.SessionWindow.OfMinutes(3);
+        var def = global::Kafka.Ksql.Linq.SessionWindow.OfMinutes(3);
         var ts = TimeSpan.FromMinutes(3);
         var ops = GetOperations(def);
         Assert.Equal(new[] { ("SessionWindow", (object?)null), ("Gap", (object?)ts) }, ops);

--- a/tests/Extensions/WindowInfoAndOffsetExtensionsTests.cs
+++ b/tests/Extensions/WindowInfoAndOffsetExtensionsTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Extensions;
+
+public class WindowInfoAndOffsetExtensionsTests
+{
+    [Fact]
+    public void WindowStart_ThrowsWhenInvoked()
+    {
+        var grouping = new[] { 1 }.GroupBy(x => x).First();
+        Assert.Throws<NotSupportedException>(() => grouping.WindowStart());
+    }
+
+    [Fact]
+    public void WindowEnd_ThrowsWhenInvoked()
+    {
+        var grouping = new[] { 1 }.GroupBy(x => x).First();
+        Assert.Throws<NotSupportedException>(() => grouping.WindowEnd());
+    }
+
+    [Fact]
+    public void LatestByOffset_ThrowsWhenInvoked()
+    {
+        var grouping = new[] { 1 }.GroupBy(x => x).First();
+        Expression<Func<int, int>> selector = x => x;
+        Assert.Throws<NotSupportedException>(() => grouping.LatestByOffset(selector));
+    }
+
+    [Fact]
+    public void EarliestByOffset_ThrowsWhenInvoked()
+    {
+        var grouping = new[] { 1 }.GroupBy(x => x).First();
+        Expression<Func<int, int>> selector = x => x;
+        Assert.Throws<NotSupportedException>(() => grouping.EarliestByOffset(selector));
+    }
+}


### PR DESCRIPTION
## Summary
- create new `Extensions` test folder
- test `HoppingWindow` and `SessionWindow` builders
- ensure `WindowInfoExtensions` and `OffsetAggregateExtensions` throw at runtime

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860da216e7c8327b42a75a55d8f60c0