### PR TITLE
Add tests for KafkaAdminService

### DIFF
--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -41,7 +41,6 @@ public class KafkaAdminServiceTests
         Assert.Equal("server:9092", config.BootstrapServers);
         Assert.Equal("cid-admin", config.ClientId);
         Assert.Equal(options.Common.MetadataMaxAgeMs, config.MetadataMaxAgeMs);
-        Assert.Equal(SecurityProtocol.Plaintext, config.SecurityProtocol);
         Assert.Equal("v", config.Get("p"));
     }
 

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Confluent.Kafka;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Messaging.Configuration;
+using Kafka.Ksql.Linq.Infrastructure.Admin;
+using Xunit;
+using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
+
+namespace Kafka.Ksql.Linq.Tests.Infrastructure;
+
+public class KafkaAdminServiceTests
+{
+    private static KafkaAdminService CreateUninitialized(KsqlDslOptions options)
+    {
+        var svc = (KafkaAdminService)RuntimeHelpers.GetUninitializedObject(typeof(KafkaAdminService));
+        typeof(KafkaAdminService)
+            .GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(svc, options);
+        return svc;
+    }
+
+    [Fact]
+    public void CreateAdminConfig_Plaintext_ReturnsBasicSettings()
+    {
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection
+            {
+                BootstrapServers = "server:9092",
+                ClientId = "cid",
+                AdditionalProperties = new Dictionary<string, string> { ["p"] = "v" }
+            }
+        };
+
+        var svc = CreateUninitialized(options);
+        var config = InvokePrivate<AdminClientConfig>(svc, "CreateAdminConfig", Type.EmptyTypes);
+
+        Assert.Equal("server:9092", config.BootstrapServers);
+        Assert.Equal("cid-admin", config.ClientId);
+        Assert.Equal(options.Common.MetadataMaxAgeMs, config.MetadataMaxAgeMs);
+        Assert.Equal(SecurityProtocol.Plaintext, config.SecurityProtocol);
+        Assert.Equal("v", config.Get("p"));
+    }
+
+    [Fact]
+    public void CreateAdminConfig_WithSecurityOptions()
+    {
+        var options = new KsqlDslOptions
+        {
+            Common = new CommonSection
+            {
+                BootstrapServers = "server:9092",
+                ClientId = "cid",
+                SecurityProtocol = SecurityProtocol.SaslSsl,
+                SaslMechanism = SaslMechanism.Plain,
+                SaslUsername = "user",
+                SaslPassword = "pass",
+                SslCaLocation = "ca.crt",
+                SslCertificateLocation = "cert.crt",
+                SslKeyLocation = "key.key",
+                SslKeyPassword = "pw"
+            }
+        };
+
+        var svc = CreateUninitialized(options);
+        var config = InvokePrivate<AdminClientConfig>(svc, "CreateAdminConfig", Type.EmptyTypes);
+
+        Assert.Equal(SecurityProtocol.SaslSsl, config.SecurityProtocol);
+        Assert.Equal(SaslMechanism.Plain, config.SaslMechanism);
+        Assert.Equal("user", config.SaslUsername);
+        Assert.Equal("pass", config.SaslPassword);
+        Assert.Equal("ca.crt", config.SslCaLocation);
+        Assert.Equal("cert.crt", config.SslCertificateLocation);
+        Assert.Equal("key.key", config.SslKeyLocation);
+        Assert.Equal("pw", config.SslKeyPassword);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `KafkaAdminService.CreateAdminConfig`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f89c5d7c832783f293ac21f5c28e