### PR TITLE
Add unit tests for low branch coverage

### DIFF
--- a/tests/Query/Ksql/KsqlDbRestApiClientExtractValueTests.cs
+++ b/tests/Query/Ksql/KsqlDbRestApiClientExtractValueTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Net.Http;
+using System;
 using Kafka.Ksql.Linq.Query.Ksql;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
@@ -19,9 +20,9 @@ public class KsqlDbRestApiClientExtractValueTests
     public void ExtractValue_HandlesVariousJsonTypes()
     {
         Assert.Equal("abc", CallExtract("\"abc\""));
-        Assert.Equal(123, CallExtract("123"));
-        Assert.Equal(10000000000L, CallExtract("10000000000"));
-        Assert.Equal(3.5, CallExtract("3.5"));
+        Assert.Equal(123, Convert.ToInt32(CallExtract("123")));
+        Assert.Equal(10000000000L, Convert.ToInt64(CallExtract("10000000000")));
+        Assert.Equal(3.5, Convert.ToDouble(CallExtract("3.5")));
         Assert.True((bool)CallExtract("true"));
         Assert.False((bool)CallExtract("false"));
         Assert.Null(CallExtract("null"));

--- a/tests/Query/Ksql/KsqlDbRestApiClientExtractValueTests.cs
+++ b/tests/Query/Ksql/KsqlDbRestApiClientExtractValueTests.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using System.Net.Http;
+using Kafka.Ksql.Linq.Query.Ksql;
+using Xunit;
+using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Ksql;
+
+public class KsqlDbRestApiClientExtractValueTests
+{
+    private static object CallExtract(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var client = new KsqlDbRestApiClient("http://unit", new HttpClient());
+        return InvokePrivate<object>(client, "ExtractValue", new[] { typeof(JsonElement) }, null, doc.RootElement);
+    }
+
+    [Fact]
+    public void ExtractValue_HandlesVariousJsonTypes()
+    {
+        Assert.Equal("abc", CallExtract("\"abc\""));
+        Assert.Equal(123, CallExtract("123"));
+        Assert.Equal(10000000000L, CallExtract("10000000000"));
+        Assert.Equal(3.5, CallExtract("3.5"));
+        Assert.True((bool)CallExtract("true"));
+        Assert.False((bool)CallExtract("false"));
+        Assert.Null(CallExtract("null"));
+        Assert.Equal("{}", CallExtract("{}"));
+    }
+}

--- a/tests/Serialization/AvroExceptionTests.cs
+++ b/tests/Serialization/AvroExceptionTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Serialization.Avro.Exceptions;
 using System;
+using System.Collections.Generic;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 

--- a/tests/Serialization/AvroExceptionTests.cs
+++ b/tests/Serialization/AvroExceptionTests.cs
@@ -77,4 +77,29 @@ public class AvroExceptionTests
         Assert.Contains("ResourceExhausted", msg);
         Assert.Contains("HUMAN INTERVENTION REQUIRED", msg);
     }
+
+    [Fact]
+    public void DetermineOperationalAction_AllCategories_ReturnsAction()
+    {
+        var expectations = new Dictionary<SchemaRegistrationFailureCategory, string>
+        {
+            [SchemaRegistrationFailureCategory.NetworkFailure] = "connectivity",
+            [SchemaRegistrationFailureCategory.AuthenticationFailure] = "credentials",
+            [SchemaRegistrationFailureCategory.SchemaIncompatible] = "schema compatibility",
+            [SchemaRegistrationFailureCategory.RegistryUnavailable] = "Registry service status",
+            [SchemaRegistrationFailureCategory.ConfigurationError] = "application configuration",
+            [SchemaRegistrationFailureCategory.ResourceExhausted] = "disk space",
+            [SchemaRegistrationFailureCategory.Unknown] = "application logs"
+        };
+
+        foreach (var kvp in expectations)
+        {
+            var action = InvokePrivate<string>(typeof(SchemaRegistrationFatalException),
+                "DetermineOperationalAction",
+                new[] { typeof(SchemaRegistrationFailureCategory) },
+                null,
+                kvp.Key);
+            Assert.Contains(kvp.Value, action);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expand AvroExceptionTests to cover all SchemaRegistrationFailureCategory cases
- add tests for ExtractValue in KsqlDbRestApiClient to exercise JSON handling logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860fb2fae44832798733728fd31b3ea