### PR TITLE
Add VisitWindowDef unit tests

### DIFF
--- a/tests/Query/Builders/WindowBuilderVisitWindowDefTests.cs
+++ b/tests/Query/Builders/WindowBuilderVisitWindowDefTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Reflection;
+using Kafka.Ksql.Linq.Query.Builders;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders;
+
+public class WindowBuilderVisitWindowDefTests
+{
+    [Fact]
+    public void VisitWindowDef_WhenNoWindowTypeDefined_ShouldReturnUnknownClause()
+    {
+        var visitorType = typeof(WindowBuilder).GetNestedType("WindowExpressionVisitor", BindingFlags.NonPublic)!;
+        var visitor = Activator.CreateInstance(visitorType)!;
+
+        var def = new global::Kafka.Ksql.Linq.WindowDef()
+            .Size(TimeSpan.FromSeconds(10));
+
+        visitorType.GetMethod("VisitWindowDef")!.Invoke(visitor, new object[] { def });
+        var result = (string)visitorType.GetMethod("BuildWindowClause")!.Invoke(visitor, null)!;
+
+        Assert.Equal("WINDOW UNKNOWN", result);
+    }
+
+    [Fact]
+    public void VisitWindowDef_WhenTumblingWindowWithFullOptions_ShouldBuildExpectedClause()
+    {
+        var visitorType = typeof(WindowBuilder).GetNestedType("WindowExpressionVisitor", BindingFlags.NonPublic)!;
+        var visitor = Activator.CreateInstance(visitorType)!;
+
+        var def = new global::Kafka.Ksql.Linq.WindowDef()
+            .TumblingWindow()
+            .Size(TimeSpan.FromSeconds(30))
+            .Retention(TimeSpan.FromDays(1))
+            .GracePeriod(TimeSpan.FromMinutes(1))
+            .EmitFinal();
+
+        visitorType.GetMethod("VisitWindowDef")!.Invoke(visitor, new object[] { def });
+        var result = (string)visitorType.GetMethod("BuildWindowClause")!.Invoke(visitor, null)!;
+
+        Assert.Equal("WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1 DAYS, GRACE PERIOD 1 MINUTES) EMIT FINAL", result);
+    }
+
+    [Fact]
+    public void VisitWindowDef_WhenHoppingWindowWithFullOptions_ShouldBuildExpectedClause()
+    {
+        var visitorType = typeof(WindowBuilder).GetNestedType("WindowExpressionVisitor", BindingFlags.NonPublic)!;
+        var visitor = Activator.CreateInstance(visitorType)!;
+
+        var def = new global::Kafka.Ksql.Linq.WindowDef()
+            .HoppingWindow()
+            .Size(TimeSpan.FromMinutes(2))
+            .AdvanceBy(TimeSpan.FromMinutes(1))
+            .Retention(TimeSpan.FromHours(1))
+            .GracePeriod(TimeSpan.FromSeconds(5))
+            .EmitFinal();
+
+        visitorType.GetMethod("VisitWindowDef")!.Invoke(visitor, new object[] { def });
+        var result = (string)visitorType.GetMethod("BuildWindowClause")!.Invoke(visitor, null)!;
+
+        Assert.Equal("WINDOW HOPPING (SIZE 2 MINUTES, ADVANCE BY 1 MINUTES, RETENTION 1 HOURS, GRACE PERIOD 5 SECONDS) EMIT FINAL", result);
+    }
+
+    [Fact]
+    public void VisitWindowDef_WhenSessionWindowWithGapSpecified_ShouldBuildExpectedClause()
+    {
+        var visitorType = typeof(WindowBuilder).GetNestedType("WindowExpressionVisitor", BindingFlags.NonPublic)!;
+        var visitor = Activator.CreateInstance(visitorType)!;
+
+        var def = new global::Kafka.Ksql.Linq.WindowDef()
+            .SessionWindow()
+            .Gap(TimeSpan.FromSeconds(45));
+
+        visitorType.GetMethod("VisitWindowDef")!.Invoke(visitor, new object[] { def });
+        var result = (string)visitorType.GetMethod("BuildWindowClause")!.Invoke(visitor, null)!;
+
+        Assert.Equal("WINDOW SESSION (GAP 45 SECONDS)", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated tests for `WindowBuilder`'s `VisitWindowDef` method

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686109d560c88327b45c830b27282bcb