### PR TITLE
Add SchemaRegistry meta provider

### DIFF
--- a/docs/namespaces/schema_registry_tools_namespace_doc.md
+++ b/docs/namespaces/schema_registry_tools_namespace_doc.md
@@ -1,0 +1,40 @@
+# SchemaRegistryTools 詳細設計
+
+## 🎯 責務・設計方針
+
+### 主要責務
+- **Readonly Entityメタ生成**: Schema Registryから取得したAvroスキーマを解析し、キー/バリュー型情報を含むMetaを生成
+- **Mapping登録補助**: 生成したMetaを既存のMappingへ登録して、Consumer/Deserializer層が利用できるようにする
+
+### 設計原則・制約
+- **Query層から独立**: LINQ解析に依存せずスキーマ情報のみからMetaを構築する
+- **単一責任**: Readonly時の特別処理は本namespaceに閉じ込め、他層に影響を与えない
+
+### 他namespaceとの境界
+- **Serialization**: `ISchemaRegistryClient` を受け取り、スキーマ取得のみを行う
+- **Application**: 生成したMetaはApplication層のMappingに登録される想定
+
+---
+
+## 🏗️ 主要クラス構成
+
+| ファイル | クラス | 責務 | 変更頻度 |
+|---------|------|------|------|
+| `SchemaRegistryMetaProvider.cs` | SchemaRegistryMetaProvider | スキーマ取得→Meta生成ユーティリティ | 🟡 |
+| `SchemaRegistryMetaProvider.cs` | EntitySchemaMeta / SchemaField | メタ情報データ構造 | 🟢 |
+
+---
+
+## 🚀 運用フロー
+1. Readonly属性を持つEntity型を指定して `SchemaRegistryMetaProvider.GetMetaFromSchemaRegistryAsync()` を呼び出す
+2. Schema Registryから対象トピックの最新キー/バリュースキーマを取得
+3. Avroスキーマを解析して `EntitySchemaMeta` を生成
+4. Application層で `mapping.RegisterMeta(typeof(Log), meta);` のように登録
+5. 以降のConsumer/DeserializerはMapping経由でこのMetaを参照
+
+```csharp
+var meta = await SchemaRegistryMetaProvider.GetMetaFromSchemaRegistryAsync(typeof(Log), registryClient);
+mapping.RegisterMeta(typeof(Log), meta);
+```
+
+この流れを採用することで、Readonly EntityでもLINQ式解析を経ずに必要なメタ情報を取得できます。

--- a/src/SchemaRegistryTools/SchemaRegistryMetaProvider.cs
+++ b/src/SchemaRegistryTools/SchemaRegistryMetaProvider.cs
@@ -1,0 +1,73 @@
+using Confluent.SchemaRegistry;
+using Kafka.Ksql.Linq.Serialization.Avro.Core;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.SchemaRegistryTools;
+
+public record SchemaField(string Name, string Type);
+
+public record EntitySchemaMeta(Type EntityType, IReadOnlyList<SchemaField> KeyFields, IReadOnlyList<SchemaField> ValueFields);
+
+/// <summary>
+/// Utility methods for retrieving Avro schema definitions from Schema Registry
+/// and converting them into metadata usable by the DSL.
+/// </summary>
+public static class SchemaRegistryMetaProvider
+{
+    /// <summary>
+    /// Fetches the latest key/value schemas for the specified entity type and
+    /// converts them into <see cref="EntitySchemaMeta"/> information.
+    /// </summary>
+    /// <param name="entityType">Entity type associated with the topic.</param>
+    /// <param name="schemaRegistryClient">Schema Registry client instance.</param>
+    public static async Task<EntitySchemaMeta> GetMetaFromSchemaRegistryAsync(
+        Type entityType,
+        ISchemaRegistryClient schemaRegistryClient)
+    {
+        if (entityType == null) throw new ArgumentNullException(nameof(entityType));
+        if (schemaRegistryClient == null) throw new ArgumentNullException(nameof(schemaRegistryClient));
+
+        var topicName = entityType.Name.ToLowerInvariant();
+        var keySubject = $"{topicName}-key";
+        var valueSubject = $"{topicName}-value";
+
+        var keySchema = await schemaRegistryClient.GetRegisteredSchemaAsync(keySubject, -1);
+        var valueSchema = await schemaRegistryClient.GetRegisteredSchemaAsync(valueSubject, -1);
+
+        var keyFields = ParseFields(keySchema.SchemaString);
+        var valueFields = ParseFields(valueSchema.SchemaString);
+
+        return new EntitySchemaMeta(entityType, keyFields, valueFields);
+    }
+
+    private static IReadOnlyList<SchemaField> ParseFields(string schemaJson)
+    {
+        var schema = JsonSerializer.Deserialize<AvroSchema>(schemaJson,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+            ?? new AvroSchema();
+        var fields = new List<SchemaField>();
+        foreach (var f in schema.Fields)
+        {
+            var typeName = ExtractTypeName(f.Type);
+            fields.Add(new SchemaField(f.Name, typeName));
+        }
+        return fields;
+    }
+
+    private static string ExtractTypeName(object typeInfo)
+    {
+        switch (typeInfo)
+        {
+            case string s:
+                return s;
+            case JsonElement elem when elem.ValueKind == JsonValueKind.String:
+                return elem.GetString() ?? string.Empty;
+            default:
+                return typeInfo.ToString() ?? string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SchemaRegistryMetaProvider` for fetching schema info and converting to entity metadata
- document new namespace `SchemaRegistryTools` with usage examples

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c9128cd8832786a2cf03f6d739a3